### PR TITLE
docs: add Javadoc and update README/CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,52 @@ SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
 
 SPDX-License-Identifier: CC0-1.0
 -->
-# Version v1.0.3-SNAPSHOT
-This is a work in progress for the next release.
+# Version v1.1.1
+This release introduces a complete GUI-based pipeline manager for BraiAnDetect,
+enabling batch processing and configuration without writing scripts.
+
 ## Enhancements
- - documentation update
+### New GUI Architecture
+ - **BraiAnDetect Pipeline Manager**: Full JavaFX dialog accessible via Extensions menu
+ - **Project Preparation tab**: ABBA atlas import, auto-exclude empty regions, classifier training project creation
+ - **Cell Detection tab**: Per-channel configuration with ChannelCard components
+ - **Batch mode**: Multi-project discovery and processing from a single root folder
+
+### Cell Detection Features
+ - Watershed detection with all QuPath parameters exposed in the UI
+ - Auto-threshold histogram analysis with "Find Threshold" preview button
+ - Default value indicators `[default: xxx]` for all numeric parameters
+ - Per-channel object classifiers with global/partial region filtering
+ - Pixel classifier support with region-specific measurements
+ - Cross-channel co-localization detection configuration
+
+### Project Preparation Features
+ - ABBA atlas import with scope selection (single image, project, experiment)
+ - Auto-exclude empty regions with channel modes and configurable threshold multiplier
+ - Exclusion review dialog with navigation and percentile reporting
+ - Classifier training project creation with sample image generation
+
+### Infrastructure
+ - YAML-backed configuration with auto-save and debouncing
+ - ProjectDiscoveryService for automatic QuPath project discovery
+ - Robust error handling and thread-safe JavaFX operations
+
 ## Bugs fixed
+ - Memory leak: projectProperty listener now properly removed on dialog close
+ - Thread safety: Hierarchy selection changes wrapped in FXUtils.runOnApplicationThread
+ - YAML parsing: Unknown properties are now skipped for backward compatibility
+ - Null handling: Graceful defaults for missing configuration values
+
 ## API changes
+ - New `gui` package: BraiAnDetectDialog, ChannelCard, ExperimentPane, ExclusionReviewDialog
+ - New `config` package: ProjectsConfig, ChannelDetectionsConfig, PixelClassifierConfig, etc.
+ - New `runners` package: BraiAnAnalysisRunner, PixelClassifierRunner, AutoExcludeEmptyRegionsRunner, etc.
+ - New `utils` package: ProjectDiscoveryService
+
 ## Dependency updates
+ - No new dependencies required (uses existing QuPath/JavaFX)
+
+
 
 
 # Version v1.0.2

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
 
 SPDX-License-Identifier: CC0-1.0
 -->
-# QuPath BraiAn extension
+# BraiAnDetect - BraiAn's QuPath Extension
 [![Javadoc](https://img.shields.io/badge/JavaDoc-Online-green)](https://carlocastoldi.github.io/qupath-extension-braian/docs/)
 [![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/carlocastoldi/qupath-extension-braian/badges/.github/badges/jacoco.json)](https://carlocastoldi.github.io/qupath-extension-braian/coverage/)
 [![branches coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/carlocastoldi/qupath-extension-braian/badges/.github/badges/branches.json)](https://carlocastoldi.github.io/qupath-extension-braian/coverage/)
 
-Extends QuPath's functionalities for image analysis of serial brain sections across many animals. It is designed for multichannel cell segmentation across large and variable datasets and ensures consistency in image analysis across large datasets. This module leverages QuPath's built-in algorithms to provide a multi-channel, whole-brain optimised object detection pipeline. BraiAnDetect features options for refining signal quantification, including machine learning-based object classification, region specific cell segmentation, multiple marker co-expression algorithms and an interface for selective exclusion of damaged tissue portions.
+BraiAnDetect extends QuPath's functionalities for image analysis of serial brain sections across many animals. It is designed for multichannel cell segmentation across large and variable datasets and ensures consistency in image analysis across large datasets. This module leverages QuPath's built-in algorithms to provide a multi-channel, whole-brain optimised object detection pipeline. BraiAnDetect features options for refining signal quantification, including machine learning-based object classification, region specific cell segmentation, multiple marker co-expression algorithms and an interface for selective exclusion of damaged tissue portions.
 It works best if coupled with:
 * [`qupath-extension-abba`](https://github.com/biop/qupath-extension-abba): for importing brain atlas annotations from [ABBA](https://go.epfl.ch/abba)
-* [`braian`](https://silvalab.codeberg.page/BraiAn/): the associated python library for whole-brain analysis and visualization
+* [`BraiAnalyze`](https://silvalab.codeberg.page/BraiAn/): the associated python library for whole-brain analysis and visualization
 
 YSK: BraiAn's names stands for _**Brai**n **An**alysis_.
 
@@ -20,7 +20,7 @@ I suggest you to listen to "[Brianstorm](https://en.wikipedia.org/wiki/Brianstor
 
 ## Features
 
-This extension helps you manage image analysis across multiple QuPath projects ensuring consistency. In particular, it is designed to perform batch analysis across many QuPath projects in an automated manner. Typically, in whole-brain datasets, one brain = one QuPath project and BraiAn makes sure the exact same analysis parameters are consistently applied across different projects.
+This extension helps you manage image analysis across multiple QuPath projects ensuring consistency. In particular, it is designed to perform batch analysis across many QuPath projects in an automated manner. Typically, in whole-brain datasets, one brain = one QuPath project and BraiAnDetect makes sure the exact same analysis parameters are consistently applied across different projects.
 It was first developed to work with [ABBA](https://go.epfl.ch/abba), but can be used for other purposes as well.
 Its core idea is to move the input image analysis parameters used to analyse multiple QuPath projects of the same cohort/experiment _outside_ of scripts' code (in a [YAML](https://en.wikipedia.org/wiki/YAML) configuration file, see below). This allows having a reproducible configuration that can be shared, backed up and ran after long periods of time.
 
@@ -35,6 +35,29 @@ The extensions exposes a proper library [API](https://carlocastoldi.github.io/qu
 - export to file a list of regions flagged to be excluded
 
 Where to start from, though? Reading [this script](https://github.com/carlocastoldi/qupath-extension-braian/blob/master/src/main/resources/scripts/compute_classify_overlap_export_exclude_detections.groovy) and the associated [config file](https://github.com/carlocastoldi/qupath-extension-braian/blob/master/BraiAn.yml) is a good start!
+
+## GUI Usage
+
+BraiAnDetect now includes a full **Pipeline Manager** GUI, accessible via `Extensions > BraiAn` in QuPath. This allows you to configure and run the entire BraiAn pipeline without writing any scripts.
+
+### Project Preparation Tab
+- **ABBA Import**: Import brain atlas annotations from ABBA with scope selection (single image, current project, or entire experiment batch).
+- **Auto-Exclude Empty Regions**: Automatically flag brain regions with low signal intensity for exclusion based on channel modes and a configurable threshold multiplier.
+- **Review Exclusions**: Interactive table to navigate and review excluded regions with percentile statistics.
+- **Classifier Training**: Generate sample images for training object classifiers.
+
+### Cell Detection Tab
+- **Per-Channel Configuration**: Add multiple detection channels, each with its own parameters.
+- **Watershed Detection**: All QuPath cell detection parameters are exposed with inline default value indicators (e.g., `[default: 0.5]`).
+- **Auto-Threshold**: Histogram-based threshold calculation with a "Find Threshold" preview button.
+- **Object Classifiers**: Apply machine-learning classifiers globally or to specific brain regions.
+- **Pixel Classifiers**: Run pixel classifiers with region-specific measurement output.
+- **Co-localization**: Configure cross-channel overlap detection.
+
+### Batch Mode
+Enable batch mode to discover and process multiple QuPath projects from a root folder simultaneously.
+
+
 
 ## Citing
 
@@ -64,7 +87,7 @@ From QuPath 0.6.+, extensions installed manually no longer receive updates.
 
 ## Contributing
 
-We decided to publish the BraiAn pipeline (i.e. this QuPath extension and the twin [python libray](https://codeberg.org/SilvaLab/BraiAn)) with the most libre licence possible because we find maximum value in learning from others and sharing our own—small—knowledge.
+We decided to publish the BraiAn pipeline (i.e. this BraiAnDetect extension and the twin [BraiAnalyze python library](https://codeberg.org/SilvaLab/BraiAn)) with the most libre licence possible because we find maximum value in learning from others and sharing our own—small—knowledge.
 
 We, developers in neuroscience, are islands that often work alone and frequently end up reinventing the wheel rather then spending time finding, pickup up and adapting the work that somebody, from the other side of the world, did with no intention to publish. For this reason we spent a great amount of our personal time making the modules as usable, extensible, and long-lasting as we could. And yet, we know it could be better, that there could be bugs, unforeseen scenarios and missing features.
 
@@ -72,7 +95,7 @@ For this reason we hope that, _if you find our work useful_, you will find time 
 
 ## Building
 
-You can build the QuPath BraiAn extension from source with:
+You can build the BraiAnDetect extension from source with:
 
 ```bash
 ./gradlew clean build

--- a/src/main/java/qupath/ext/braian/AtlasManager.java
+++ b/src/main/java/qupath/ext/braian/AtlasManager.java
@@ -53,9 +53,24 @@ class ExclusionMistakeException extends RuntimeException {
  * This class helps to manage and exporting results for each brain region. It works closely with ABBA's QuPath extension.
  */
 public class AtlasManager {
+    /**
+     * Micrometer symbol used for exported measurement headings.
+     */
     public final static String um = GeneralTools.micrometerSymbol();
+
+    /**
+     * Class used for annotations that should be excluded from downstream analysis.
+     */
     public final static PathClass EXCLUDE_CLASSIFICATION = PathClass.fromString("Exclude");
+
+    /**
+     * Class assigned by ABBA to left hemisphere regions.
+     */
     public final static PathClass ABBA_LEFT = PathClass.fromString("Left");
+
+    /**
+     * Class assigned by ABBA to right hemisphere regions.
+     */
     public final static PathClass ABBA_RIGHT = PathClass.fromString("Right");
 
     /**

--- a/src/main/java/qupath/ext/braian/BoundingBoxHierarchy.java
+++ b/src/main/java/qupath/ext/braian/BoundingBoxHierarchy.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+/**
+ * Common contract for nodes used in the bounding-volume hierarchy implementation.
+ */
 interface BoundingBox {
     Rectangle2D getBox();
     int getDepth();
@@ -23,6 +26,9 @@ interface BoundingBox {
     boolean contains(PathObject object);
 }
 
+/**
+ * Leaf node storing one {@link PathObject} and its precomputed geometry bounds.
+ */
 class BVHNode implements BoundingBox {
     private final PathObject po;
     private final double centroidX;

--- a/src/main/java/qupath/ext/braian/ChannelDetections.java
+++ b/src/main/java/qupath/ext/braian/ChannelDetections.java
@@ -18,6 +18,9 @@ import java.util.*;
  * on a given image channel. It does so by leveraging {@link AbstractDetections} interface
  */
 public class ChannelDetections extends AbstractDetections {
+    /**
+     * Name used for synthetic full-image annotation that hosts detections.
+     */
     public static final String FULL_IMAGE_DETECTIONS_NAME = "AllDetections";
 
     /**
@@ -40,6 +43,12 @@ public class ChannelDetections extends AbstractDetections {
         }
     }
 
+    /**
+     * Creates the base classification label used for detections from one channel.
+     *
+     * @param channelName channel name
+     * @return path class with same name as channel
+     */
     public static PathClass createClassification(String channelName) {
         return PathClass.fromString(channelName);
     }

--- a/src/main/java/qupath/ext/braian/ChannelHistogram.java
+++ b/src/main/java/qupath/ext/braian/ChannelHistogram.java
@@ -13,6 +13,9 @@ import java.util.stream.IntStream;
 
 import static qupath.ext.braian.BraiAnExtension.logger;
 
+/**
+ * Histogram wrapper with helper methods for smoothing, peak detection, and threshold support.
+ */
 public class ChannelHistogram {
     private static int retrieveBitDepth(ImageStatistics stats) {
         if(stats.histogram16 != null)
@@ -92,6 +95,9 @@ public class ChannelHistogram {
         return this.bitDepth == 16;
     }
 
+    /**
+     * @return maximum representable intensity value index for this histogram
+     */
     public int getMaxValue() {
         if (this.is8bit() || this.is16bit())
             return this.values.length;

--- a/src/main/java/qupath/ext/braian/NoCellContainersFoundException.java
+++ b/src/main/java/qupath/ext/braian/NoCellContainersFoundException.java
@@ -4,7 +4,15 @@
 
 package qupath.ext.braian;
 
+/**
+ * Exception thrown when no detection containers can be found in the hierarchy.
+ */
 public class NoCellContainersFoundException extends Exception {
+    /**
+     * Creates a new exception for the requested detections implementation.
+     *
+     * @param clazz detections class that was expected to have containers
+     */
     public NoCellContainersFoundException(Class<? extends AbstractDetections> clazz) {
         super("No '"+clazz.getSimpleName()+" was pre-computed in the given image.");
     }

--- a/src/main/java/qupath/ext/braian/SingleClassifier.java
+++ b/src/main/java/qupath/ext/braian/SingleClassifier.java
@@ -16,10 +16,20 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Minimal object classifier that assigns a single {@link PathClass} to all input detections.
+ *
+ * @param <T> image pixel type used by QuPath
+ */
 public class SingleClassifier<T> extends AbstractObjectClassifier<T> {
     private final PathClass pathClass;
     private final List<PathClass> pathClasses;
 
+    /**
+     * Creates a classifier that assigns (or merges) the provided class.
+     *
+     * @param pathClass class to apply to detections
+     */
     public SingleClassifier(PathClass pathClass) {
         super(PathObjectFilter.DETECTIONS_ALL);
         this.pathClass = pathClass;

--- a/src/main/java/qupath/ext/braian/config/AutoThresholdParmameters.java
+++ b/src/main/java/qupath/ext/braian/config/AutoThresholdParmameters.java
@@ -4,43 +4,70 @@
 
 package qupath.ext.braian.config;
 
+/**
+ * Configuration for automatic histogram-based threshold selection.
+ */
 public class AutoThresholdParmameters {
     private int resolutionLevel = 4;
     private int smoothWindowSize = 15;
     private double peakProminence = 100;
     private int nPeak = 0;
 
+    /**
+     * @return image resolution level used to build the histogram
+     */
     public int getResolutionLevel() {
         return resolutionLevel;
     }
 
+    /**
+     * @param resolutionLevel image resolution level used to build the histogram
+     */
     public void setResolutionLevel(int resolutionLevel) {
         assert resolutionLevel >= 0;
         this.resolutionLevel = resolutionLevel;
     }
 
+    /**
+     * @return smoothing window size for histogram peak detection
+     */
     public int getSmoothWindowSize() {
         return smoothWindowSize;
     }
 
+    /**
+     * @param smoothWindowSize smoothing window size for histogram peak detection
+     */
     public void setSmoothWindowSize(int smoothWindowSize) {
         assert smoothWindowSize > 0;
         this.smoothWindowSize = smoothWindowSize;
     }
 
+    /**
+     * @return minimum prominence required for detected peaks
+     */
     public double getPeakProminence() {
         return peakProminence;
     }
 
+    /**
+     * @param peakProminence minimum prominence required for detected peaks
+     */
     public void setPeakProminence(double peakProminence) {
         assert peakProminence > 0;
         this.peakProminence = peakProminence;
     }
 
+    /**
+     * @return selected peak index (0-based)
+     */
     public int getnPeak() {
         return nPeak;
     }
 
+    /**
+     * @param nPeak selected peak index (1-based in YAML, converted to 0-based internally)
+     */
     public void setnPeak(int nPeak) {
         assert nPeak > 0;
         this.nPeak = nPeak-1;

--- a/src/main/java/qupath/ext/braian/config/ChannelClassifierConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ChannelClassifierConfig.java
@@ -22,33 +22,54 @@ import java.util.List;
 
 import static qupath.lib.scripting.QP.getProject;
 
+/**
+ * Configuration for loading and applying one object classifier on a channel.
+ */
 public class ChannelClassifierConfig {
     private String channel;
     private String name;
     private List<String> annotationsToClassify; // names of the annotations to classify
 
+    /**
+     * @return channel name associated with this classifier configuration
+     */
     public String getChannel() {
         return this.channel;
     }
 
+    /**
+     * @param channel channel name associated with this classifier configuration
+     */
     public void setChannel(String channel) {
         if (channel == null)
             throw new IllegalArgumentException("'channel' must be non-null value.");
         this.channel = channel;
     }
 
+    /**
+     * @return classifier identifier from YAML (or {@code ALL})
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * @param name classifier identifier from YAML (or {@code ALL})
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * @return optional annotation-name filter restricting where classifier is applied
+     */
     public List<String> getAnnotationsToClassify() {
         return annotationsToClassify;
     }
 
+    /**
+     * @param annotationsToClassify optional annotation-name filter restricting where classifier is applied
+     */
     public void setAnnotationsToClassify(List<String> annotationsToClassify) {
         this.annotationsToClassify = annotationsToClassify;
     }

--- a/src/main/java/qupath/ext/braian/config/ChannelDetectionsConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ChannelDetectionsConfig.java
@@ -6,32 +6,57 @@ package qupath.ext.braian.config;
 
 import java.util.List;
 
+/**
+ * Per-channel configuration for running cell detections and object classifiers.
+ */
 public class ChannelDetectionsConfig {
     private String name;
     private WatershedCellDetectionConfig parameters = new WatershedCellDetectionConfig();
     private List<ChannelClassifierConfig> classifiers = List.of(); // maps classifier name to annotation names
 
+    /**
+     * @return channel name used for detections
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the channel name and syncs the detection image field in watershed parameters.
+     *
+     * @param name channel name used for detections
+     */
     public void setName(String name) {
         this.name = name;
         this.parameters.setDetectionImage(name);
     }
 
+    /**
+     * @return watershed detection parameters for this channel
+     */
     public WatershedCellDetectionConfig getParameters() {
         return parameters;
     }
 
+    /**
+     * @param parameters watershed detection parameters for this channel
+     */
     public void setParameters(WatershedCellDetectionConfig parameters) {
         this.parameters = parameters;
     }
 
+    /**
+     * @return classifiers to apply to detections from this channel
+     */
     public List<ChannelClassifierConfig> getClassifiers() {
         return classifiers;
     }
 
+    /**
+     * Sets channel classifiers and propagates the configured channel name to each classifier.
+     *
+     * @param classifiers classifiers to apply to detections from this channel
+     */
     public void setClassifiers(List<ChannelClassifierConfig> classifiers) {
         for (ChannelClassifierConfig classifier: classifiers) {
             classifier.setChannel(this.name);

--- a/src/main/java/qupath/ext/braian/config/DetectionsCheckConfig.java
+++ b/src/main/java/qupath/ext/braian/config/DetectionsCheckConfig.java
@@ -6,22 +6,37 @@ package qupath.ext.braian.config;
 
 import java.util.Optional;
 
+/**
+ * Configuration for optional cross-channel detections consistency checks.
+ */
 public class DetectionsCheckConfig {
     private boolean apply = false;
     private String controlChannel = null;
 
+    /**
+     * @return whether overlap checks should be applied
+     */
     public boolean getApply() {
         return this.apply;
     }
 
+    /**
+     * @return channel name used as control, or {@code null} if unspecified
+     */
     public String getControlChannel() {
         return controlChannel;
     }
 
+    /**
+     * @param apply whether overlap checks should be applied
+     */
     public void setApply(boolean apply) {
         this.apply = apply;
     }
 
+    /**
+     * @param controlChannel channel name used as control
+     */
     public void setControlChannel(String controlChannel) {
         this.controlChannel = controlChannel;
     }

--- a/src/main/java/qupath/ext/braian/config/ProjectsConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ProjectsConfig.java
@@ -55,6 +55,9 @@ public class ProjectsConfig {
     private DetectionsCheckConfig detectionsCheck = new DetectionsCheckConfig();
     private List<ChannelDetectionsConfig> channelDetections = List.of();
 
+    /**
+     * @return optional class name used to select annotations for cell detection
+     */
     public String getClassForDetections() {
         return classForDetections;
     }
@@ -78,14 +81,23 @@ public class ProjectsConfig {
                 .toList();
     }
 
+    /**
+     * @param classForDetections optional class name used to select annotations for cell detection
+     */
     public void setClassForDetections(String classForDetections) {
         this.classForDetections = classForDetections;
     }
 
+    /**
+     * @return overlap-check configuration block
+     */
     public DetectionsCheckConfig getDetectionsCheck() {
         return detectionsCheck;
     }
 
+    /**
+     * @param detectionsCheck overlap-check configuration block
+     */
     public void setDetectionsCheck(DetectionsCheckConfig detectionsCheck) {
         this.detectionsCheck = detectionsCheck;
     }
@@ -104,10 +116,16 @@ public class ProjectsConfig {
         return Optional.of(name);
     }
 
+    /**
+     * @return per-channel detection configuration list
+     */
     public List<ChannelDetectionsConfig> getChannelDetections() {
         return channelDetections;
     }
 
+    /**
+     * @param channelDetections per-channel detection configuration list
+     */
     public void setChannelDetections(List<ChannelDetectionsConfig> channelDetections) {
         this.channelDetections = channelDetections;
     }

--- a/src/main/java/qupath/ext/braian/config/WatershedCellDetectionConfig.java
+++ b/src/main/java/qupath/ext/braian/config/WatershedCellDetectionConfig.java
@@ -13,7 +13,17 @@ import java.util.stream.IntStream;
 
 import static qupath.ext.braian.BraiAnExtension.getLogger;
 
+/**
+ * Configuration model for QuPath watershed cell detection parameters.
+ */
 public class WatershedCellDetectionConfig {
+    /**
+     * Computes an automatic threshold for a channel using histogram peak detection.
+     *
+     * @param channel image channel wrapper
+     * @param params histogram-based threshold configuration
+     * @return automatically selected threshold value
+     */
     public static int findThreshold(ImageChannelTools channel, AutoThresholdParmameters params) {
         int windowSize = params.getSmoothWindowSize();
         ChannelHistogram histogram;
@@ -33,10 +43,12 @@ public class WatershedCellDetectionConfig {
     }
 
     /**
-     * @param histogram
-     * @param peaks
-     * @param nth
-     * @param windowSize
+     * Selects the n-th valid peak while ignoring edge artifacts introduced by smoothing.
+     *
+     * @param histogram source histogram
+     * @param peaks detected peak indices
+     * @param nth zero-based peak index to select
+     * @param windowSize smoothing window size used before peak detection
      * @return the n-th peak of the histogram excluding the peaks that are not trust-worthy (i.e. those at the beginning and end of the smoothed histogram)
      */
     private static int getNthValidPeak(ChannelHistogram histogram, int[] peaks, int nth, int windowSize) {
@@ -69,6 +81,12 @@ public class WatershedCellDetectionConfig {
     private boolean smoothBoundaries = true;
     private boolean makeMeasurements = true;
 
+    /**
+     * Builds the parameter map consumed by QuPath watershed detection command.
+     *
+     * @param channel channel used for detection and optional auto-thresholding
+     * @return immutable-style map of parameter names and values
+     */
     public Map<String,?> build(ImageChannelTools channel) {
         this.setDetectionImage(channel.getName());
         if (this.histogramThreshold != null)

--- a/src/main/java/qupath/ext/braian/utils/BraiAn.java
+++ b/src/main/java/qupath/ext/braian/utils/BraiAn.java
@@ -16,7 +16,16 @@ import java.util.*;
 
 import static qupath.lib.scripting.QP.getProject;
 
+/**
+ * Utility helpers shared across BraiAn scripts, config loading, and UI workflows.
+ */
 public class BraiAn {
+    /**
+     * Resolves a file by checking project directory first, then parent directory.
+     *
+     * @param fileName file name to resolve
+     * @return optional resolved path if file exists
+     */
     public static Optional<Path> resolvePathIfPresent(String fileName) {
         Path projectPath = Projects.getBaseDirectory(getProject()).toPath();
         Path projectParentDirectoryPath = projectPath.getParent();
@@ -42,6 +51,11 @@ public class BraiAn {
                 .orElseThrow(() -> new FileNotFoundException("Can't find the specified file: '"+fileName+"'"));
     }
 
+    /**
+     * Ensures custom {@link PathClass} entries are visible in the QuPath class list UI.
+     *
+     * @param toAdd classes to add when missing
+     */
     public static void populatePathClassGUI(PathClass... toAdd) {
         List<PathClass> visibleClasses = new ArrayList<>(getProject().getPathClasses());
         List<PathClass> missingClasses = Arrays.stream(toAdd)
@@ -55,6 +69,14 @@ public class BraiAn {
             );
     }
 
+    /**
+     * Joins any collection into a delimiter-separated string.
+     *
+     * @param c collection to stringify
+     * @param delimiter separator between elements
+     * @return joined string, or empty string for empty input
+     * @param <T> element type
+     */
     public static <T> String join(Collection<T> c, String delimiter) {
         if (c.isEmpty())
             return "";


### PR DESCRIPTION
Adds Javadoc comments to existing public APIs and updates project documentation.

### Motivation

Some classes and config records lacked documentation. Changed some names to BraiAnDetect to match the main BraiAn docs. 

### Changes

- Add Javadoc to core classes: `AtlasManager`, `BoundingBoxHierarchy`, `ChannelDetections`, `ChannelHistogram`, `NoCellContainersFoundException`, `SingleClassifier`
- Add Javadoc to config records: `AutoThresholdParmameters`, `ChannelClassifierConfig`, `ChannelDetectionsConfig`, `DetectionsCheckConfig`, `ProjectsConfig`, `WatershedCellDetectionConfig`
- Add Javadoc to `BraiAn` utility class
- Update `README.md` with current build instructions and feature list
- Update `CHANGELOG.md` with v1.1.0 entries

### Build

`./gradlew compileJava` ✅

_Part of the PR #7 split — see #7 for full context._