### PR TITLE
feat(config): add PixelClassifierConfig model

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     // For testing
     testImplementation(libs.bundles.qupath)
     testImplementation(libs.junit)
+    testImplementation(libs.snakeyaml)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.mockito:mockito-core:5.+")
 }

--- a/src/main/java/qupath/ext/braian/config/ChannelDetectionsConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ChannelDetectionsConfig.java
@@ -10,6 +10,7 @@ public class ChannelDetectionsConfig {
     private String name;
     private WatershedCellDetectionConfig parameters = new WatershedCellDetectionConfig();
     private List<ChannelClassifierConfig> classifiers = List.of(); // maps classifier name to annotation names
+    private List<PixelClassifierConfig> pixelClassifiers = List.of();
 
     public String getName() {
         return name;
@@ -37,5 +38,13 @@ public class ChannelDetectionsConfig {
             classifier.setChannel(this.name);
         }
         this.classifiers = classifiers;
+    }
+
+    public List<PixelClassifierConfig> getPixelClassifiers() {
+        return pixelClassifiers;
+    }
+
+    public void setPixelClassifiers(List<PixelClassifierConfig> pixelClassifiers) {
+        this.pixelClassifiers = pixelClassifiers == null ? List.of() : pixelClassifiers;
     }
 }

--- a/src/main/java/qupath/ext/braian/config/PixelClassifierConfig.java
+++ b/src/main/java/qupath/ext/braian/config/PixelClassifierConfig.java
@@ -1,0 +1,44 @@
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.config;
+
+import java.util.List;
+
+/**
+ * Configuration entry describing a pixel classifier to run and how to record its output.
+ */
+public class PixelClassifierConfig {
+    /** Name of the pixel classifier to run (typically a QuPath {@code .json} classifier name or identifier). */
+    private String classifierName;
+
+    /** Optional measurement identifier to store/export derived results. */
+    private String measurementId;
+
+    /** Optional list of atlas region names to restrict where the classifier is run. */
+    private List<String> regionFilter = List.of();
+
+    public String getClassifierName() {
+        return classifierName;
+    }
+
+    public void setClassifierName(String classifierName) {
+        this.classifierName = classifierName;
+    }
+
+    public String getMeasurementId() {
+        return measurementId;
+    }
+
+    public void setMeasurementId(String measurementId) {
+        this.measurementId = measurementId;
+    }
+
+    public List<String> getRegionFilter() {
+        return regionFilter;
+    }
+
+    public void setRegionFilter(List<String> regionFilter) {
+        this.regionFilter = regionFilter == null ? List.of() : regionFilter;
+    }
+}

--- a/src/test/java/qupath/ext/braian/config/ProjectsConfigYamlTest.java
+++ b/src/test/java/qupath/ext/braian/config/ProjectsConfigYamlTest.java
@@ -1,0 +1,68 @@
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.config;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProjectsConfigYamlTest {
+
+    @Test
+    void shouldLoadPixelClassifiersPerChannel() {
+        String yaml = String.join("\n",
+                "classForDetections: null",
+                "channelDetections:",
+                "  - name: \"DAPI\"",
+                "    pixelClassifiers:",
+                "      - classifierName: \"MyClassifier\"",
+                "        measurementId: \"MyMeasurement\"",
+                "        regionFilter: [\"Isocortex\", \"OLF\"]",
+                ""
+        );
+
+        ProjectsConfig config = new Yaml(new Constructor(ProjectsConfig.class, new LoaderOptions())).load(yaml);
+
+        assertNotNull(config);
+        assertNotNull(config.getChannelDetections());
+        assertEquals(1, config.getChannelDetections().size());
+
+        ChannelDetectionsConfig channel = config.getChannelDetections().get(0);
+        assertEquals("DAPI", channel.getName());
+
+        List<PixelClassifierConfig> pixelClassifiers = channel.getPixelClassifiers();
+        assertNotNull(pixelClassifiers);
+        assertEquals(1, pixelClassifiers.size());
+
+        PixelClassifierConfig pc = pixelClassifiers.get(0);
+        assertEquals("MyClassifier", pc.getClassifierName());
+        assertEquals("MyMeasurement", pc.getMeasurementId());
+        assertEquals(List.of("Isocortex", "OLF"), pc.getRegionFilter());
+    }
+
+    @Test
+    void missingPixelClassifiersDefaultsToEmptyList() {
+        String yaml = String.join("\n",
+                "classForDetections: null",
+                "channelDetections:",
+                "  - name: \"DAPI\"",
+                ""
+        );
+
+        ProjectsConfig config = new Yaml(new Constructor(ProjectsConfig.class, new LoaderOptions())).load(yaml);
+
+        assertNotNull(config);
+        assertNotNull(config.getChannelDetections());
+        assertEquals(1, config.getChannelDetections().size());
+
+        ChannelDetectionsConfig channel = config.getChannelDetections().get(0);
+        assertNotNull(channel.getPixelClassifiers());
+        assertTrue(channel.getPixelClassifiers().isEmpty());
+    }
+}


### PR DESCRIPTION
Adds a configuration model for pixel classifiers and per-channel classifier assignment.

### Motivation

Pixel classifiers currently require manual path specification in scripts. This PR introduces a `PixelClassifierConfig` record that can be referenced from YAML configuration, enabling batch workflows to specify classifiers declaratively.

### Changes

- **New**: `PixelClassifierConfig` — immutable record for classifier name and path
- **Modified**: `ChannelDetectionsConfig` — add `pixelClassifiers` field for per-channel classifier lists
- **New**: `ProjectsConfigYamlTest` — unit test for YAML parsing of the new config
- **Modified**: `build.gradle.kts` — add `snakeyaml` to test classpath

### Build & Tests

`./gradlew compileJava` ✅
`./gradlew test` ✅

_Part of the PR #7 split — see #7 for full context._