### PR TITLE
feat(config): add atlasName and per-channel detection options

### DIFF
--- a/BraiAn.yml
+++ b/BraiAn.yml
@@ -10,6 +10,8 @@
 # If a value is not defined in the YAML, BraiAn will apply a default value.
 classForDetections: null                  # DEFAULT: null (i.e. applies BraiAn on the whole image)
                                           #               Class of the annotations in which BraiAn's cell detection analysis is desired
+atlasName: "allen_mouse_10um_java"        # DEFAULT: "allen_mouse_10um_java"
+                                          #               ABBA atlas name/identifier to use when importing/working with atlas regions
 detectionsCheck:
   apply: true                             # DEFAULT: false
                                           #               If set to true, each detection on a channel (different from 'controlChannel') is ascribable to a cell detection in the 'controlChannel'.
@@ -23,6 +25,10 @@ detectionsCheck:
 channelDetections:                        # DEFAULT: empty (i.e. BraiAn does not work on any imagge channel)
   # - name: "DAPI"                        # if no parameters are defined for one channel, BraiAn will use QuPath's default values
   - name: "AF568" # cFos
+    inputChannelID: 1                    # DEFAULT: 1 (1-based)
+                                          #               Source channel index to use if channel names are ambiguous
+    enableCellDetection: true            # DEFAULT: true
+                                          #               If false, skip cell detection for this channel
     parameters:
       requestedPixelSizeMicrons: 1        # DEFAULT: 0.5
                                           #               Choose pixel size at which detection will be performed - higher values are likely to be faster, but may be less accurate;
@@ -78,6 +84,8 @@ channelDetections:                        # DEFAULT: empty (i.e. BraiAn does not
         annotationsToClassify:            # DEFAULT: empty (i.e. the classifier is applied on all detections)
                                           #               List of the annotation names for which the classifier is applied
   - name: "AF647" # Arc1
+    inputChannelID: 1
+    enableCellDetection: true
     parameters:
       requestedPixelSizeMicrons: 1
       # Nucleus parameters

--- a/src/main/java/qupath/ext/braian/config/ChannelDetectionsConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ChannelDetectionsConfig.java
@@ -9,7 +9,26 @@ import java.util.List;
 public class ChannelDetectionsConfig {
     private String name;
     private WatershedCellDetectionConfig parameters = new WatershedCellDetectionConfig();
+
+    /**
+     * 1-based input channel index to use when the display name does not uniquely identify the source.
+     */
+    private int inputChannelID = 1;
+
+    /**
+     * Whether cell detection should run for this channel.
+     */
+    private boolean enableCellDetection = true;
+
     private List<ChannelClassifierConfig> classifiers = List.of(); // maps classifier name to annotation names
+
+    public int getInputChannelID() {
+        return inputChannelID;
+    }
+
+    public void setInputChannelID(int inputChannelID) {
+        this.inputChannelID = inputChannelID;
+    }
 
     public String getName() {
         return name;
@@ -37,5 +56,13 @@ public class ChannelDetectionsConfig {
             classifier.setChannel(this.name);
         }
         this.classifiers = classifiers;
+    }
+
+    public boolean isEnableCellDetection() {
+        return enableCellDetection;
+    }
+
+    public void setEnableCellDetection(boolean enableCellDetection) {
+        this.enableCellDetection = enableCellDetection;
     }
 }

--- a/src/main/java/qupath/ext/braian/config/ProjectsConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ProjectsConfig.java
@@ -52,6 +52,13 @@ public class ProjectsConfig {
     }
 
     private String classForDetections = null;
+
+    /**
+     * Name of the ABBA atlas to use when importing/working with atlas regions.
+     * <p>
+     * This should match the atlas identifier configured in the ABBA extension.
+     */
+    private String atlasName = "allen_mouse_10um_java";
     private DetectionsCheckConfig detectionsCheck = new DetectionsCheckConfig();
     private List<ChannelDetectionsConfig> channelDetections = List.of();
 
@@ -80,6 +87,14 @@ public class ProjectsConfig {
 
     public void setClassForDetections(String classForDetections) {
         this.classForDetections = classForDetections;
+    }
+
+    public String getAtlasName() {
+        return atlasName;
+    }
+
+    public void setAtlasName(String atlasName) {
+        this.atlasName = atlasName;
     }
 
     public DetectionsCheckConfig getDetectionsCheck() {


### PR DESCRIPTION
Extends the YAML configuration with fields needed for GUI-driven workflows.

### Motivation

The GUI pipeline manager needs to know which atlas to target and which input channel ID to use for each detection channel. These were previously hardcoded assumptions.

### Changes

- **Modified**: `ProjectsConfig` — add `atlasName` field with getter
- **Modified**: `ChannelDetectionsConfig` — add `inputChannelID` and `enableCellDetection` fields
- **Modified**: `BraiAn.yml` — document the new fields with example values

### Build

`./gradlew compileJava` ✅

_Part of the PR #7 split — see #7 for full context._