### PR TITLE
feat: auto-exclude empty atlas regions via adaptive Otsu thresholding

### DIFF
--- a/src/main/java/qupath/ext/braian/AtlasManager.java
+++ b/src/main/java/qupath/ext/braian/AtlasManager.java
@@ -19,13 +19,13 @@ import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.projects.ProjectImageEntry;
 import qupath.lib.regions.RegionRequest;
-import qupath.lib.roi.interfaces.ROI;
 import qupath.lib.scripting.QP;
 
 import ij.ImagePlus;
+import ij.process.ImageProcessor;
+import ij.process.AutoThresholder;
 import ij.gui.Roi;
 import ij.measure.ResultsTable;
-import ij.process.ImageProcessor;
 import java.awt.image.BufferedImage;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -46,20 +46,22 @@ class ImportedAtlasNotFound extends RuntimeException {
 
 class DisruptedAtlasHierarchy extends RuntimeException {
     public DisruptedAtlasHierarchy(PathObject atlas) {
-        super("The atlas hierarchy '"+atlas+"' was disrupted. "+
+        super("The atlas hierarchy '" + atlas + "' was disrupted. " +
                 "You must import the atlas annotations again and delete any previous region annotation.");
     }
 }
 
 class ExclusionMistakeException extends RuntimeException {
     public ExclusionMistakeException() {
-        super("Some regions in the atlas ontology were wrongly classified as '"+AtlasManager.EXCLUDE_CLASSIFICATION+"'.\n"+
+        super("Some regions in the atlas ontology were wrongly classified as '" + AtlasManager.EXCLUDE_CLASSIFICATION
+                + "'.\n" +
                 "You can try to fix this by calling fixExclusions() on the AtlasManager instance.");
     }
 }
 
 /**
- * This class helps to manage and exporting results for each brain region. It works closely with ABBA's QuPath extension.
+ * This class helps to manage and exporting results for each brain region. It
+ * works closely with ABBA's QuPath extension.
  */
 public class AtlasManager {
     public final static String um = GeneralTools.micrometerSymbol();
@@ -67,10 +69,11 @@ public class AtlasManager {
     public final static PathClass ABBA_LEFT = PathClass.fromString("Left");
     public final static PathClass ABBA_RIGHT = PathClass.fromString("Right");
 
-    private static final int AUTO_EXCLUDE_RESOLUTION_LEVEL = 4;
+    private static final int AUTO_THRESHOLD_RESOLUTION_LEVEL = 4;
 
     /**
      * Checks whether at least one ABBA atlas was previously imported.
+     * 
      * @param hierarchy where to search for the atlas
      * @return true if an ABBA atlas was previously imported
      */
@@ -80,8 +83,10 @@ public class AtlasManager {
 
     /**
      * Checks whether a specific ABBA atlas was previously imported.
+     * 
      * @param atlasName the name of the atlas to check.
-     *                  If null, it checks whether <i>any</i> atlas was imported with ABBA
+     *                  If null, it checks whether <i>any</i> atlas was imported
+     *                  with ABBA
      * @param hierarchy where to search for the atlas
      * @return true if the atlas was previously imported
      */
@@ -93,8 +98,8 @@ public class AtlasManager {
         return hierarchy.getAnnotationObjects()
                 .stream()
                 .filter(o -> "Root".equals(o.getName()) &&
-                            (atlasName == null || (o.getPathClass() != null && o.getPathClass().getName().equals(atlasName)))
-                        )
+                        (atlasName == null
+                                || (o.getPathClass() != null && o.getPathClass().getName().equals(atlasName))))
                 .toList();
     }
 
@@ -103,8 +108,7 @@ public class AtlasManager {
                 Stream.of(parent),
                 parent.getChildObjects().stream()
                         .filter(o -> o instanceof PathAnnotationObject)
-                        .flatMap(AtlasManager::flattenObjectStream)
-        );
+                        .flatMap(AtlasManager::flattenObjectStream));
     }
 
     private static List<PathObject> flattenObject(PathObject parent) {
@@ -115,16 +119,19 @@ public class AtlasManager {
         // TODO: should avoid resorting to QP to get the server metadata
         PixelCalibration cal = QP.getCurrentImageData().getServerMetadata().getPixelCalibration();
         if (!um.equals(cal.getPixelWidthUnit()) || !um.equals(cal.getPixelHeightUnit()))
-            throw new RuntimeException("FAILED to export results. Expected image pixel units to be in 'µm', instead got them in '"+
-                    cal.getPixelWidthUnit()+"' and '"+cal.getPixelWidthUnit()+"'. Try setting it with setPixelSizeMicrons()");
-        Stream<String> genericMeasurements = Stream.of("Name", "Classification", "Area "+um+"^2", "Num Detections");
-        Stream<String> detectionsMeasurements = detections.stream().flatMap(d -> d.getDetectionsPathClasses().stream().map(pc -> "Num "+pc.getName()));
+            throw new RuntimeException(
+                    "FAILED to export results. Expected image pixel units to be in 'µm', instead got them in '" +
+                            cal.getPixelWidthUnit() + "' and '" + cal.getPixelWidthUnit()
+                            + "'. Try setting it with setPixelSizeMicrons()");
+        Stream<String> genericMeasurements = Stream.of("Name", "Classification", "Area " + um + "^2", "Num Detections");
+        Stream<String> detectionsMeasurements = detections.stream()
+                .flatMap(d -> d.getDetectionsPathClasses().stream().map(pc -> "Num " + pc.getName()));
         return Stream.concat(genericMeasurements, detectionsMeasurements).toList();
     }
 
     private static List<PathObject> getExclusionAnnotations(PathObjectHierarchy hierarchy) {
         return hierarchy.getAnnotationObjects().stream()
-                .filter( ann -> ann.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION )
+                .filter(ann -> ann.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION)
                 .toList();
     }
 
@@ -133,10 +140,11 @@ public class AtlasManager {
 
     /**
      * Constructs a manager of the specified atlas imported with ABBA.
+     * 
      * @param atlasName the name of the atlas that was imported with ABBA.
      *                  If null, it selects the first available.
      * @param hierarchy where to search for the atlas
-     * @throws ImportedAtlasNotFound if the specified atlas was not found
+     * @throws ImportedAtlasNotFound   if the specified atlas was not found
      * @throws DisruptedAtlasHierarchy if the found atlas hierarchy was disrupted
      */
     public AtlasManager(String atlasName, PathObjectHierarchy hierarchy) {
@@ -147,14 +155,16 @@ public class AtlasManager {
         this.atlasObject = atlases.getFirst();
         if (this.atlasObject.getChildObjects().isEmpty())
             throw new DisruptedAtlasHierarchy(this.atlasObject);
-        if (atlases.size()>1)
+        if (atlases.size() > 1)
             getLogger().warn("Several imported atlases have been found. Selecting: {}", this.atlasObject);
     }
 
     /**
      * Constructs a manager of the first available atlas imported with ABBA.
+     * 
      * @param hierarchy where to search for an atlas
-     * @throws ImportedAtlasNotFound if no atlas was not found in the object hierarchy
+     * @throws ImportedAtlasNotFound   if no atlas was not found in the object
+     *                                 hierarchy
      * @throws DisruptedAtlasHierarchy if the found atlas hierarchy was disrupted
      * @see AtlasManager(String, PathObjectHierarchy)
      */
@@ -171,10 +181,13 @@ public class AtlasManager {
 
     /**
      * Flattens the atlas's ontology into a list of annotations.
-     * It may return some non-region annotations too, if the atlas hierarchy was modified with added/removed elements.
+     * It may return some non-region annotations too, if the atlas hierarchy was
+     * modified with added/removed elements.
+     * 
      * @return the list of all brain regions in the atlas
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      * @see #flatten(List)
      */
     public List<PathObject> flatten() {
@@ -185,13 +198,17 @@ public class AtlasManager {
 
     /**
      * Flattens the atlas ontology into a list of annotations.
-     * If the atlas hierarchy was modified by adding {@link AbstractDetections}'s containers,
+     * If the atlas hierarchy was modified by adding {@link AbstractDetections}'s
+     * containers,
      * it filters them from the current brain hierarchy.
      * <br>
-     * It may still return some non-region annotations, if the atlas hierarchy was further modified with added/removed elements.
+     * It may still return some non-region annotations, if the atlas hierarchy was
+     * further modified with added/removed elements.
+     * 
      * @return the list of all brain regions in the atlas
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      * @see #flatten()
      */
     public List<PathObject> flatten(List<AbstractDetections> detections) {
@@ -206,21 +223,33 @@ public class AtlasManager {
 
     /**
      * Saves a TSV file containing data for each brain region of the atlas.
-     * Namely, Image name, brain region name, hemisphere, area in µm², number of detections for each of the given types.
-     * The table is saved as a CSV (comma-separated values) file if 'file' ends with ".csv"
-     * @param detections the list of detection of which to gather the data for each region
-     * @param file the file where it should write to. Note that if the file exists, it will be overwritten
-     * @throws ExclusionMistakeException if the atlas hierarchy contains regions classified as {@link #EXCLUDE_CLASSIFICATION}.
-     * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     * Namely, Image name, brain region name, hemisphere, area in µm², number of
+     * detections for each of the given types.
+     * The table is saved as a CSV (comma-separated values) file if 'file' ends with
+     * ".csv"
+     * 
+     * @param detections the list of detection of which to gather the data for each
+     *                   region
+     * @param file       the file where it should write to. Note that if the file
+     *                   exists, it will be overwritten
+     * @throws ExclusionMistakeException if the atlas hierarchy contains regions
+     *                                   classified as
+     *                                   {@link #EXCLUDE_CLASSIFICATION}.
+     * @throws DisruptedAtlasHierarchy   if the current atlas hierarchy was
+     *                                   disrupted,
+     *                                   and it cannot find all the brain region
+     *                                   organised according to the atlas's
+     *                                   hierarchy
      */
-    // Olivier Burri <https://github.com/lacan> wrote mostly of this function and published under Apache-2.0 license for qupath-extension-biop
+    // Olivier Burri <https://github.com/lacan> wrote mostly of this function and
+    // published under Apache-2.0 license for qupath-extension-biop
     public boolean saveResults(List<AbstractDetections> detections, File file) {
         if (this.atlasObject.getChildObjects().isEmpty())
             throw new DisruptedAtlasHierarchy(this.atlasObject);
         if (file.exists())
-            if(!file.delete()) {
-                getLogger().error("Could not delete previous results file {}, the file could be locked.", file.getName());
+            if (!file.delete()) {
+                getLogger().error("Could not delete previous results file {}, the file could be locked.",
+                        file.getName());
                 return false;
             }
         QP.mkdirs(file.getAbsoluteFile().getParent());
@@ -249,13 +278,14 @@ public class AtlasManager {
             // Check if image has associated metadata and add it as columns
             if (!entry.getMetadata().isEmpty()) {
                 Map<String, String> metadata = entry.getMetadata();
-                for(String key: metadata.keySet()) {
+                for (String key : metadata.keySet()) {
                     results.addValue("Metadata_" + key, metadata.get(key));
                 }
             }
 
             // Then we can add the results the user requested
-            // Because the Mu is sometimes poorly formatted, we remove them in favor of a 'u'
+            // Because the Mu is sometimes poorly formatted, we remove them in favor of a
+            // 'u'
             for (String col : AtlasManager.getDetectionsMeasurements(detections)) {
                 if (ob.isNumericMeasurement(col)) {
                     numericValue = ob.getNumericValue(brainRegion, col);
@@ -268,14 +298,18 @@ public class AtlasManager {
             }
         }
         boolean isSaved = results.save(file.getAbsolutePath());
-        getLogger().info("Results '{}' Saved under '{}', contains {} rows", file.getName(), file.getParentFile().getAbsolutePath(), results.size());
+        getLogger().info("Results '{}' Saved under '{}', contains {} rows", file.getName(),
+                file.getParentFile().getAbsolutePath(), results.size());
         return isSaved;
     }
 
     /**
-     * Gets all the annotations that are covered by another annotation, classified as "Exclude"
+     * Gets all the annotations that are covered by another annotation, classified
+     * as "Exclude"
+     * 
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      */
     private Set<PathObject> getExcludedAnnotations() {
         if (this.atlasObject.getChildObjects().isEmpty())
@@ -283,27 +317,33 @@ public class AtlasManager {
         List<PathObject> excludeAnnotations = AtlasManager.getExclusionAnnotations(this.hierarchy);
         getLogger().info("Exclusion annotations: [{}]", BraiAn.join(excludeAnnotations, ", "));
         // We export all the annotations that are not "Exclude" or named "Root".
-        // This serves as a downstream ~check~ that the slice has nothing else other than the atlas annotations and the exclusions
+        // This serves as a downstream ~check~ that the slice has nothing else other
+        // than the atlas annotations and the exclusions
         var otherAnnotations = this.hierarchy.getAnnotationObjects().stream()
-                .filter( ann -> ann.getPathClass() != AtlasManager.EXCLUDE_CLASSIFICATION && ann != this.atlasObject)
+                .filter(ann -> ann.getPathClass() != AtlasManager.EXCLUDE_CLASSIFICATION && ann != this.atlasObject)
                 .toList();
         // Loop over exclusions that contain the annotations to be removed/excluded
         return excludeAnnotations.stream()
                 .map(exclusion -> exclusion.getROI().getGeometry())
-                .flatMap(exclusion -> otherAnnotations.stream().filter(ann -> ann.getROI().getGeometry().coveredBy(exclusion)))
+                .flatMap(exclusion -> otherAnnotations.stream()
+                        .filter(ann -> ann.getROI().getGeometry().coveredBy(exclusion)))
                 .collect(Collectors.toSet());
     }
 
     /**
-     * Gets all the brain regions that should be excluded from further analysis due to being missing or badly aligned to the image.
+     * Gets all the brain regions that should be excluded from further analysis due
+     * to being missing or badly aligned to the image.
      * A brain region, in order to be excluded, must:
      * <ul>
-     *   <li>either be contained into a larger annotation, classified as "Exclude"
-     * 	 <li>or be <b>duplicated</b> (SHIFT+D) outside the Atlas's hierarchy, and then classified as "Exclude"
+     * <li>either be contained into a larger annotation, classified as "Exclude"
+     * <li>or be <b>duplicated</b> (SHIFT+D) outside the Atlas's hierarchy, and then
+     * classified as "Exclude"
      * </ul>
+     * 
      * @return a set of brain regions' annotations that should be excluded.
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      */
     public Set<PathObject> getExcludedBrainRegions() {
         Set<PathObject> annotationsToExcludeFlattened = this.getExcludedAnnotations();
@@ -313,12 +353,13 @@ public class AtlasManager {
         Set<PathObject> weirdExcludedAnnotations = annotationsToExcludeFlattened.stream()
                 .filter(o -> !regionsToExcludeFlattened.contains(o)).collect(Collectors.toSet());
         if (!weirdExcludedAnnotations.isEmpty())
-            getLogger().error("Annotations excluded outside atlas ontology will be ignored. Make sure these annotations weren't meant to be classified as  '{}': [{}]",
+            getLogger().error(
+                    "Annotations excluded outside atlas ontology will be ignored. Make sure these annotations weren't meant to be classified as  '{}': [{}]",
                     EXCLUDE_CLASSIFICATION.toString(),
                     BraiAn.join(weirdExcludedAnnotations, ", "));
         // remove 'child' annotations that are descendant of an excluded parent
         var regionsToExclude = new HashSet<>(regionsToExcludeFlattened);
-        for (PathObject r1: regionsToExcludeFlattened) {
+        for (PathObject r1 : regionsToExcludeFlattened) {
             List<PathObject> descendants = AtlasManager.flattenObject(r1);
             for (PathObject r2 : regionsToExcludeFlattened)
                 if (descendants.indexOf(r2) > 0) // in 0 there is r1 itself, the parent annotation
@@ -328,11 +369,15 @@ public class AtlasManager {
     }
 
     /**
-     * Saves a file containing, on each line, the name and hemisphere of the regions to be excluded.
-     * @param file the file where it should write to. Note that if the file exists, it will be overwritten
+     * Saves a file containing, on each line, the name and hemisphere of the regions
+     * to be excluded.
+     * 
+     * @param file the file where it should write to. Note that if the file exists,
+     *             it will be overwritten
      * @return true if the file was correctly saved.
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      * @see #getExcludedBrainRegions()
      * @see #saveResults(List, File)
      */
@@ -340,13 +385,15 @@ public class AtlasManager {
         if (this.atlasObject.getChildObjects().isEmpty())
             throw new DisruptedAtlasHierarchy(this.atlasObject);
         if (file.exists())
-            if(!file.delete()) {
-                getLogger().error("Could not delete previous exclusion file {}, the file could be locked.", file.getName());
+            if (!file.delete()) {
+                getLogger().error("Could not delete previous exclusion file {}, the file could be locked.",
+                        file.getName());
                 return false;
             }
         QP.mkdirs(file.getAbsoluteFile().getParent());
 
-        Set<PathObject> regionsToExcludeSet = this.getExcludedBrainRegions(); // NOTE: may return things that aren't brain regions
+        Set<PathObject> regionsToExcludeSet = this.getExcludedBrainRegions(); // NOTE: may return things that aren't
+                                                                              // brain regions
 
         List<PathObject> regionsToExclude = regionsToExcludeSet.stream()
                 .filter(o -> o.getPathClass() != null)
@@ -366,112 +413,179 @@ public class AtlasManager {
             getLogger().error("Error saving excluded regions: {}", e.getMessage());
             return false;
         }
-        getLogger().info("Exclusions '{}' Saved under '{}', contains {} rows", file.getName(), file.getParentFile().getAbsolutePath(), regionsToExclude.size());
+        getLogger().info("Exclusions '{}' Saved under '{}', contains {} rows", file.getName(),
+                file.getParentFile().getAbsolutePath(), regionsToExclude.size());
         return true;
     }
 
     /**
-     * Automatically excludes atlas regions that appear empty based on Otsu thresholding of the nuclei channel.
+     * Automatically excludes atlas regions that appear empty based on adaptive Otsu
+     * thresholding.
      *
-     * <p>A region is excluded if its mean intensity in the nuclei channel is below the Otsu threshold,
-     * computed on a downsampled representation of the same channel.
-     *
-     * <p>Exclusion is performed by creating a duplicate annotation outside the atlas hierarchy and
-     * assigning it the {@link #EXCLUDE_CLASSIFICATION} class.
-     *
-     * @param imageData image used to compute intensities
-     * @param nucleiChannelName channel used for tissue detection (e.g. DAPI)
-     * @param manualThreshold optional manual threshold override; if null, Otsu is used
-     * @return reports for newly excluded regions
+     * @param imageData            the image data
+     * @param channelNames         the list of channel names to consider
+     * @param useMaxAcrossChannels if true, a region is kept if its max intensity
+     *                             across all channels
+     *                             is above the threshold
+     * @param thresholdMultiplier  multiplier applied to the calculated Otsu
+     *                             threshold
+     * @return a list of exclusion reports
      */
     public List<ExclusionReport> autoExcludeEmptyRegions(
             ImageData<BufferedImage> imageData,
-            String nucleiChannelName,
-            Integer manualThreshold
-    ) {
+            List<String> channelNames,
+            boolean useMaxAcrossChannels,
+            double thresholdMultiplier) {
         Objects.requireNonNull(imageData, "imageData");
-        Objects.requireNonNull(nucleiChannelName, "nucleiChannelName");
+        Objects.requireNonNull(channelNames, "channelNames");
 
-        int threshold;
-        if (manualThreshold != null) {
-            threshold = manualThreshold;
-        } else {
+        if (channelNames.isEmpty()) {
+            return List.of();
+        }
+
+        // 1. Calculate Otsu thresholds for each channel
+        Map<String, Integer> otsuThresholds = new HashMap<>();
+        for (String channelName : channelNames) {
             try {
-                ImageChannelTools channel = new ImageChannelTools(nucleiChannelName, imageData);
-                ChannelHistogram histogram = channel.getHistogram(AUTO_EXCLUDE_RESOLUTION_LEVEL);
-                threshold = histogram.otsuThreshold();
-                getLogger().info("Computed Otsu threshold for channel '{}': {}", nucleiChannelName, threshold);
+                ImageChannelTools channel = new ImageChannelTools(channelName, imageData);
+                ImageProcessor ip = channel.getImageProcessor(AUTO_THRESHOLD_RESOLUTION_LEVEL);
+                AutoThresholder thresholder = new AutoThresholder();
+                int threshold = thresholder.getThreshold(AutoThresholder.Method.Otsu, ip.getHistogram());
+                otsuThresholds.put(channelName, threshold);
+                getLogger().info("Computed Otsu threshold for channel '{}': {}", channelName, threshold);
             } catch (Exception e) {
-                getLogger().error("Failed to compute Otsu threshold for channel '{}': {}", nucleiChannelName,
-                        e.getMessage());
-                return List.of();
+                getLogger().error("Failed to compute Otsu threshold for channel '{}': {}", channelName, e.getMessage());
             }
         }
 
+        if (otsuThresholds.isEmpty()) {
+            return List.of();
+        }
+
+        // 2. Gather intensities for all regions
+        List<PathObject> regions = flatten().stream()
+                .filter(o -> o instanceof PathAnnotationObject)
+                .filter(o -> o != this.atlasObject)
+                .filter(o -> {
+                    String name = o.getName();
+                    return name == null || (!"Root".equalsIgnoreCase(name));
+                })
+                .toList();
+
         // Avoid creating duplicate exclusions for regions already excluded
-        Set<PathObject> alreadyExcluded = getExcludedBrainRegions();
+        Set<PathObject> alreadyExcludedData = getExcludedBrainRegions();
 
-        List<ExclusionReport> reports = new ArrayList<>();
-        for (PathObject region : flatten()) {
-            if (!(region instanceof PathAnnotationObject annotation))
-                continue;
-            if (region == this.atlasObject)
-                continue;
+        // Map to store relevant intensity for each region
+        Map<PathObject, Double> regionIntensities = new HashMap<>();
+        List<Double> allIntensitiesForDistribution = new ArrayList<>();
 
-            String name = annotation.getName();
-            if (name != null && ("Root".equals(name) || "root".equals(name)))
-                continue;
-            if (alreadyExcluded.contains(region))
+        for (PathObject region : regions) {
+            if (alreadyExcludedData.contains(region))
                 continue;
 
-            ROI roi = annotation.getROI();
-            if (roi == null || !roi.isArea() || roi.getArea() <= 0)
-                continue;
+            double bestIntensity = -1.0;
+            for (String channelName : channelNames) {
+                if (!otsuThresholds.containsKey(channelName))
+                    continue;
 
-            double mean;
-            try {
-                mean = getRegionMeanIntensity(imageData, annotation, nucleiChannelName, AUTO_EXCLUDE_RESOLUTION_LEVEL);
-            } catch (Exception e) {
-                getLogger().warn("Failed to compute mean for region '{}' channel '{}': {}", annotation.getName(),
-                        nucleiChannelName, e.getMessage());
-                continue;
+                try {
+                    double mean = getRegionMean(imageData, (PathAnnotationObject) region, channelName,
+                            AUTO_THRESHOLD_RESOLUTION_LEVEL);
+                    double normalized = mean / otsuThresholds.get(channelName);
+
+                    if (useMaxAcrossChannels) {
+                        if (normalized > bestIntensity)
+                            bestIntensity = normalized;
+                    } else {
+                        bestIntensity = normalized;
+                        break; // Only use first channel (Nuclei)
+                    }
+                } catch (Exception e) {
+                    getLogger().warn("Failed to compute mean for region '{}' channel '{}'",
+                            region.getName(), channelName, e.getMessage());
+                }
             }
 
-            if (mean < threshold) {
-                PathAnnotationObject exclude = (PathAnnotationObject) PathObjects.createAnnotationObject(annotation.getROI());
-                exclude.setName(annotation.getName());
+            if (bestIntensity >= 0) {
+                regionIntensities.put(region, bestIntensity);
+                allIntensitiesForDistribution.add(bestIntensity);
+            }
+        }
+
+        if (allIntensitiesForDistribution.isEmpty())
+            return List.of();
+
+        // 3. Sort for percentile calculation
+        Collections.sort(allIntensitiesForDistribution);
+
+        List<ExclusionReport> reports = new ArrayList<>();
+        String imageName = imageData.getServerMetadata().getName();
+
+        for (Map.Entry<PathObject, Double> entry : regionIntensities.entrySet()) {
+            PathObject region = entry.getKey();
+            double intensity = entry.getValue();
+
+            // intensity is "mean / Otsu"
+            // Exclusion condition: mean < Otsu * multiplier => mean / Otsu < multiplier
+            if (intensity < thresholdMultiplier) {
+                PathAnnotationObject exclude = (PathAnnotationObject) PathObjects
+                        .createAnnotationObject(region.getROI());
+                exclude.setName(region.getName());
                 exclude.setPathClass(EXCLUDE_CLASSIFICATION);
+
+                // Calculate percentile rank (informational)
+                int rank = Collections.binarySearch(allIntensitiesForDistribution, intensity);
+                if (rank < 0)
+                    rank = -(rank + 1);
+                double percentile = (double) rank / allIntensitiesForDistribution.size() * 100.0;
+
+                // Stamp measurements
+                exclude.getMeasurementList().put("Auto-Exclude: Normalized Intensity", intensity);
+                exclude.getMeasurementList().put("Auto-Exclude: Percentile Rank", percentile);
+
                 this.hierarchy.addObject(exclude);
 
                 reports.add(new ExclusionReport(
                         null,
                         null,
-                        imageData.getServerMetadata().getName(),
+                        imageName,
                         exclude.getID(),
-                        annotation.getName(),
-                        nucleiChannelName,
-                        mean,
-                        threshold
-                ));
+                        region.getName(),
+                        percentile));
             }
         }
+
         return reports;
     }
 
-    private static RegionRequest regionRequestForRoi(ImageServer<BufferedImage> server, double downsample, ROI roi) {
-        int x = (int) Math.floor(roi.getBoundsX());
-        int y = (int) Math.floor(roi.getBoundsY());
-        int w = Math.max(1, (int) Math.ceil(roi.getBoundsWidth()));
-        int h = Math.max(1, (int) Math.ceil(roi.getBoundsHeight()));
-        return RegionRequest.createInstance(server.getPath(), downsample, x, y, w, h);
+    /**
+     * Gets currently excluded annotations (classified as
+     * {@link #EXCLUDE_CLASSIFICATION}).
+     *
+     * @param imageData the image data containing the hierarchy
+     * @return a list of exclusion reports for all excluded regions
+     */
+    public List<ExclusionReport> getExcludedRegions(ImageData<BufferedImage> imageData) {
+        Objects.requireNonNull(imageData, "imageData");
+        String imageName = imageData.getServerMetadata().getName();
+        return getExclusionAnnotations(this.hierarchy).stream()
+                .filter(o -> o instanceof PathAnnotationObject)
+                .map(o -> (PathAnnotationObject) o)
+                .map(ann -> new ExclusionReport(
+                        null,
+                        null,
+                        imageName,
+                        ann.getID(),
+                        ann.getName(),
+                        ann.getMeasurementList().get("Auto-Exclude: Percentile Rank")))
+                .toList();
     }
 
-    private static double getRegionMeanIntensity(
+    private static double getRegionMean(
             ImageData<BufferedImage> imageData,
             PathAnnotationObject region,
             String channelName,
-            int resolutionLevel
-    ) throws IOException {
+            int resolutionLevel) throws IOException {
         Objects.requireNonNull(imageData, "imageData");
         Objects.requireNonNull(region, "region");
         Objects.requireNonNull(channelName, "channelName");
@@ -479,8 +593,8 @@ public class AtlasManager {
         ImageServer<BufferedImage> server = imageData.getServer();
         ImageChannelTools channel = new ImageChannelTools(channelName, imageData);
         double downsample = server.getDownsampleForResolution(Math.min(server.nResolutions() - 1, resolutionLevel));
+        RegionRequest request = RegionRequest.createInstance(server.getPath(), downsample, region.getROI());
 
-        RegionRequest request = regionRequestForRoi(server, downsample, region.getROI());
         var pathImage = IJTools.convertToImagePlus(server, request);
         ImagePlus imp = pathImage.getImage();
 
@@ -489,19 +603,24 @@ public class AtlasManager {
 
         ImageProcessor ip = imp.getChannelProcessor().duplicate();
         Roi ijRoi = IJTools.convertToIJRoi(region.getROI(), request);
-        if (ijRoi != null)
+        if (ijRoi != null) {
             ip.setRoi(ijRoi);
-
+        }
         return ip.getStats().mean;
     }
 
     /**
      * Return whether the current atlas is split between left and right hemispheres.
-     * Atlas hierarchies that were modified by deleting one of the two hemispheres, are still recognised as split.
-     * @return true if the current atlas is split between left and right hemispheres.
+     * Atlas hierarchies that were modified by deleting one of the two hemispheres,
+     * are still recognised as split.
+     * 
+     * @return true if the current atlas is split between left and right
+     *         hemispheres.
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
-     * whether the atlas was split between left and right.
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
+     *                                 whether the atlas was split between left and
+     *                                 right.
      */
     public boolean isSplit() {
         if (this.atlasObject.getChildObjects().isEmpty())
@@ -512,33 +631,35 @@ public class AtlasManager {
         return roots.stream()
                 // anyMatch because if there are multiple "root" annotations, an
                 .anyMatch(root -> {
-                            Set<PathClass> hemispheres = flattenObject(root).stream()
-                                    .map(PathObject::getPathClass)
-                                    .filter(c -> c.isDerivedFrom(ABBA_LEFT) || c.isDerivedFrom(ABBA_RIGHT))
-                                    .map(PathClass::getParentClass)
-                                    .collect(Collectors.toSet());
-                            if (hemispheres.size() == 2)
-                                throw new DisruptedAtlasHierarchy(this.atlasObject);
-                            return hemispheres.size() == 1;
-                        }
-                );
+                    Set<PathClass> hemispheres = flattenObject(root).stream()
+                            .map(PathObject::getPathClass)
+                            .filter(c -> c.isDerivedFrom(ABBA_LEFT) || c.isDerivedFrom(ABBA_RIGHT))
+                            .map(PathClass::getParentClass)
+                            .collect(Collectors.toSet());
+                    if (hemispheres.size() == 2)
+                        throw new DisruptedAtlasHierarchy(this.atlasObject);
+                    return hemispheres.size() == 1;
+                });
     }
 
     /**
      * Attempts to fix possible mistakes with the exclusions, such as:
-     *  <ul>
-     *   <li>Exclusion of the "Root" hierarchy annotation rather than a proper region</li>
-     *   <li>If a region was excluded within the atlas hierarchy</li>
-     *   <li>If a region's classifications was removed</li>
+     * <ul>
+     * <li>Exclusion of the "Root" hierarchy annotation rather than a proper
+     * region</li>
+     * <li>If a region was excluded within the atlas hierarchy</li>
+     * <li>If a region's classifications was removed</li>
      * </ul>
+     * 
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      */
     public void fixExclusions() {
         if (this.atlasObject.getChildObjects().isEmpty())
             throw new DisruptedAtlasHierarchy(this.atlasObject);
         if (this.atlasObject.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION) {
-            for (PathObject root: this.atlasObject.getChildObjects()) {
+            for (PathObject root : this.atlasObject.getChildObjects()) {
                 PathObject duplicate = PathObjectTools.transformObject(root, null, true, true);
                 duplicate.setPathClass(AtlasManager.EXCLUDE_CLASSIFICATION);
                 this.hierarchy.addObject(duplicate);
@@ -547,32 +668,32 @@ public class AtlasManager {
         }
         this.flatten().stream()
                 .filter(
-                        region ->
-                                        (region.getPathClass() != null && region.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION) ||
-                                        (region.getPathClass() == null && region != this.atlasObject)
-                ).forEach(
-                        mistakenlyExcludedRegion -> this.fixMistakenlyExcludedRegion(mistakenlyExcludedRegion, this.isSplit())
-                );
+                        region -> (region.getPathClass() != null
+                                && region.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION) ||
+                                (region.getPathClass() == null && region != this.atlasObject))
+                .forEach(
+                        mistakenlyExcludedRegion -> this.fixMistakenlyExcludedRegion(mistakenlyExcludedRegion,
+                                this.isSplit()));
     }
 
     private void fixMistakenlyExcludedRegion(PathObject mistakenlyExcludedRegion, boolean isSplit) {
         String regionName;
         if ((regionName = mistakenlyExcludedRegion.getName()) == null)
-            throw new RuntimeException("Can't deduce the name for brain region '"+mistakenlyExcludedRegion+"'.");
+            throw new RuntimeException("Can't deduce the name for brain region '" + mistakenlyExcludedRegion + "'.");
         PathClass classification;
         if (isSplit)
-            classification = PathClass.getInstance(this.getHemisphereOfMisclassifiedRegion(mistakenlyExcludedRegion),  regionName, null);
+            classification = PathClass.getInstance(this.getHemisphereOfMisclassifiedRegion(mistakenlyExcludedRegion),
+                    regionName, null);
         else
             classification = PathClass.fromString(regionName);
         List<PathObject> wrongDuplicates = this.hierarchy.getRootObject().getChildObjects().stream().filter(
-            ann -> regionName.equals(ann.getName()) && ann.getPathClass() == classification
-        ).toList();
+                ann -> regionName.equals(ann.getName()) && ann.getPathClass() == classification).toList();
         if (wrongDuplicates.isEmpty()) {
             PathObject duplicate = PathObjectTools.transformObject(mistakenlyExcludedRegion, null, true, true);
             this.hierarchy.addObject(duplicate);
             wrongDuplicates = List.of(duplicate);
         }
-        for (PathObject wrongDuplicate: wrongDuplicates) {
+        for (PathObject wrongDuplicate : wrongDuplicates) {
             wrongDuplicate.setPathClass(AtlasManager.EXCLUDE_CLASSIFICATION);
         }
         mistakenlyExcludedRegion.setPathClass(classification);
@@ -584,11 +705,12 @@ public class AtlasManager {
             hemisphereObject = hemisphereObject.getParent();
         Set<PathClass> hemisphere = flattenObject(hemisphereObject).stream()
                 .map(PathObject::getPathClass)
-                .filter(c -> c != null && c.isDerivedClass() && (c.isDerivedFrom(ABBA_LEFT) || c.isDerivedFrom(ABBA_RIGHT)))
+                .filter(c -> c != null && c.isDerivedClass()
+                        && (c.isDerivedFrom(ABBA_LEFT) || c.isDerivedFrom(ABBA_RIGHT)))
                 .map(PathClass::getParentClass)
                 .collect(Collectors.toSet());
         if (hemisphere.size() != 1)
-            throw new RuntimeException("Can't deduce the hemisphere for '"+region+"'.");
+            throw new RuntimeException("Can't deduce the hemisphere for '" + region + "'.");
         return hemisphere.iterator().next();
     }
 }

--- a/src/main/java/qupath/ext/braian/AtlasManager.java
+++ b/src/main/java/qupath/ext/braian/AtlasManager.java
@@ -444,6 +444,8 @@ public class AtlasManager {
                 this.hierarchy.addObject(exclude);
 
                 reports.add(new ExclusionReport(
+                        null,
+                        null,
                         imageData.getServerMetadata().getName(),
                         exclude.getID(),
                         annotation.getName(),

--- a/src/main/java/qupath/ext/braian/ExclusionReport.java
+++ b/src/main/java/qupath/ext/braian/ExclusionReport.java
@@ -3,6 +3,7 @@
 
 package qupath.ext.braian;
 
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -10,6 +11,8 @@ import java.util.UUID;
  * Report entry describing one automatically-excluded atlas region.
  */
 public record ExclusionReport(
+        Path projectFile,
+        String projectName,
         String imageName,
         UUID excludedAnnotationId,
         String regionName,
@@ -21,5 +24,12 @@ public record ExclusionReport(
         Objects.requireNonNull(imageName, "imageName");
         Objects.requireNonNull(excludedAnnotationId, "excludedAnnotationId");
         Objects.requireNonNull(channelName, "channelName");
+    }
+
+    public String imageLabel() {
+        if (projectName != null && !projectName.isBlank()) {
+            return projectName + ": " + imageName;
+        }
+        return imageName;
     }
 }

--- a/src/main/java/qupath/ext/braian/ExclusionReport.java
+++ b/src/main/java/qupath/ext/braian/ExclusionReport.java
@@ -1,0 +1,25 @@
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Report entry describing one automatically-excluded atlas region.
+ */
+public record ExclusionReport(
+        String imageName,
+        UUID excludedAnnotationId,
+        String regionName,
+        String channelName,
+        double meanIntensity,
+        int otsuThreshold
+) {
+    public ExclusionReport {
+        Objects.requireNonNull(imageName, "imageName");
+        Objects.requireNonNull(excludedAnnotationId, "excludedAnnotationId");
+        Objects.requireNonNull(channelName, "channelName");
+    }
+}

--- a/src/main/java/qupath/ext/braian/ExclusionReport.java
+++ b/src/main/java/qupath/ext/braian/ExclusionReport.java
@@ -1,14 +1,25 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package qupath.ext.braian;
 
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.UUID;
 
 /**
- * Report entry describing one automatically-excluded atlas region.
+ * Immutable payload used to populate the exclusion review dialog.
+ *
+ * @param projectFile          the QuPath project file (typically
+ *                             {@code project.qpproj}); may be null for the
+ *                             current project
+ * @param projectName          the project display name; may be null
+ * @param imageName            the image entry name (as shown in the QuPath
+ *                             project)
+ * @param excludedAnnotationId the {@link java.util.UUID} of the exclusion
+ *                             annotation
+ * @param regionName           the excluded region name; may be null
+ * @param percentile           the percentile rank of the excluded region
  */
 public record ExclusionReport(
         Path projectFile,
@@ -16,16 +27,11 @@ public record ExclusionReport(
         String imageName,
         UUID excludedAnnotationId,
         String regionName,
-        String channelName,
-        double meanIntensity,
-        int otsuThreshold
-) {
-    public ExclusionReport {
-        Objects.requireNonNull(imageName, "imageName");
-        Objects.requireNonNull(excludedAnnotationId, "excludedAnnotationId");
-        Objects.requireNonNull(channelName, "channelName");
-    }
+        double percentile) {
 
+    /**
+     * @return a compact label combining project and image names
+     */
     public String imageLabel() {
         if (projectName != null && !projectName.isBlank()) {
             return projectName + ": " + imageName;

--- a/src/test/java/qupath/ext/braian/ChannelHistogramTest.java
+++ b/src/test/java/qupath/ext/braian/ChannelHistogramTest.java
@@ -25,6 +25,32 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ChannelHistogramTest {
 
     @Test
+    void otsuThreshold_shouldFallBetweenBimodalPeaks_8bit() {
+        long[] hist = new long[256];
+        hist[20] = 10_000;
+        hist[200] = 10_000;
+
+        int t = ChannelHistogram.otsuThreshold(hist);
+        assertTrue(t > 20 && t < 200, "Expected threshold between peaks, got " + t);
+    }
+
+    @Test
+    void otsuThreshold_shouldFallBetweenBimodalPeaks_16bit() {
+        long[] hist = new long[65536];
+        hist[1_000] = 10_000;
+        hist[60_000] = 10_000;
+
+        int t = ChannelHistogram.otsuThreshold(hist);
+        assertTrue(t > 1_000 && t < 60_000, "Expected threshold between peaks, got " + t);
+    }
+
+    @Test
+    void otsuThreshold_allZeroHistogram_returnsZero() {
+        long[] hist = new long[256];
+        assertEquals(0, ChannelHistogram.otsuThreshold(hist));
+    }
+
+    @Test
         // test behavior for signal without local maxima
     void constant() {
         // PREPARE


### PR DESCRIPTION
Adds automatic exclusion of atlas regions that lack tissue, using multi-channel adaptive Otsu thresholding.

### Motivation

When working with damaged tissue or missing hemispheres, manually identifying and excluding empty regions is tedious and error-prone. This feature automates the process by comparing each region's mean intensity against a per-channel Otsu threshold.

### How it works

1. Compute Otsu threshold for each specified channel at a low resolution level
2. For each atlas region, calculate the normalized intensity (mean / Otsu) per channel
3. If `useMaxAcrossChannels` is true, keep a region if *any* channel has sufficient signal (useful when tissue is stained in different channels)
4. Exclude regions where normalized intensity falls below the `thresholdMultiplier`
5. Stamp excluded annotations with `Auto-Exclude: Normalized Intensity` and `Auto-Exclude: Percentile Rank` measurements for auditability

### Changes

- **New**: `ExclusionReport` — immutable record for exclusion metadata (project, image, region, percentile)
- **New**: `ChannelHistogram` — histogram wrapper with `otsuThreshold()` method
- **Modified**: `AtlasManager` — add `autoExcludeEmptyRegions(ImageData, List<String>, boolean, double)` and `getExcludedRegions(ImageData)` methods
- **New**: `ChannelHistogramTest` — unit test for Otsu calculation

### API

```java
List<ExclusionReport> autoExcludeEmptyRegions(
    ImageData<BufferedImage> imageData,
    List<String> channelNames,        // e.g. ["DAPI", "GFP"]
    boolean useMaxAcrossChannels,     // true = keep if ANY channel has signal
    double thresholdMultiplier        // e.g. 0.5 = exclude below 50% of Otsu
)
```

### Build & Tests

`./gradlew compileJava` ✅
`./gradlew test` ✅

_Part of the PR #7 split — see #7 for full context._