### PR TITLE
refactor: replace QP.* global calls with explicit context parameters

### DIFF
--- a/src/main/java/qupath/ext/braian/AbstractDetections.java
+++ b/src/main/java/qupath/ext/braian/AbstractDetections.java
@@ -7,10 +7,12 @@ package qupath.ext.braian;
 import org.locationtech.jts.geom.Geometry;
 import qupath.ext.braian.utils.BraiAn;
 import qupath.lib.classifiers.object.ObjectClassifier;
+import qupath.lib.gui.QuPathGUI;
 import qupath.lib.images.ImageData;
 import qupath.lib.objects.*;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+import qupath.lib.projects.Project;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.GeometryTools;
 import qupath.lib.roi.interfaces.ROI;
@@ -71,12 +73,17 @@ public abstract class AbstractDetections {
      * @see #getContainersName()
      * @see #getContainersPathClass()
      */
-    public AbstractDetections(String id, Collection<PathClass> detectionClasses, PathObjectHierarchy hierarchy) throws NoCellContainersFoundException {
+    public AbstractDetections(String id,
+                              Collection<PathClass> detectionClasses,
+                              PathObjectHierarchy hierarchy,
+                              Project<?> project,
+                              QuPathGUI qupath) throws NoCellContainersFoundException {
         this.hierarchy = hierarchy;
         this.id = id;
         this.detectionClasses = detectionClasses.stream().toList();
-        for (PathClass classification: this.detectionClasses)
-            BraiAn.populatePathClassGUI(classification);
+        if (project != null) {
+            BraiAn.populatePathClassGUI(project, qupath, this.detectionClasses.toArray(new PathClass[0]));
+        }
         this.fireUpdate();
     }
 

--- a/src/main/java/qupath/ext/braian/AbstractDetections.java
+++ b/src/main/java/qupath/ext/braian/AbstractDetections.java
@@ -60,6 +60,8 @@ public abstract class AbstractDetections {
     private final String id;
     private final PathObjectHierarchy hierarchy;
     private final List<PathClass> detectionClasses;
+    private final Project<?> project;
+    private final QuPathGUI qupath;
     private List<PathAnnotationObject> containers = new ArrayList<>();
     private BoundingBoxHierarchy bbh;
 
@@ -81,6 +83,8 @@ public abstract class AbstractDetections {
         this.hierarchy = hierarchy;
         this.id = id;
         this.detectionClasses = detectionClasses.stream().toList();
+        this.project = project;
+        this.qupath = qupath;
         if (project != null) {
             BraiAn.populatePathClassGUI(project, qupath, this.detectionClasses.toArray(new PathClass[0]));
         }
@@ -374,7 +378,7 @@ public abstract class AbstractDetections {
         if (classifier.classifyObjects(imageData, cells, true) > 0)
             imageData.getHierarchy().fireObjectClassificationsChangedEvent(classifier, cells);
         PathClass discardedPC = this.getDiscardedDetectionsPathClass();
-        BraiAn.populatePathClassGUI(discardedPC);
+        BraiAn.populatePathClassGUI(project, qupath, discardedPC);
         return cells.stream().filter(d -> this.hasDetectionClass(d, false)).toList();
     }
 

--- a/src/main/java/qupath/ext/braian/AtlasManager.java
+++ b/src/main/java/qupath/ext/braian/AtlasManager.java
@@ -8,13 +8,13 @@ import qupath.ext.braian.utils.BraiAn;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.measure.ObservableMeasurementTableData;
 import qupath.lib.images.servers.PixelCalibration;
+import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.projects.ProjectImageEntry;
-import qupath.lib.scripting.QP;
 
 import ij.measure.ResultsTable;
 import java.awt.image.BufferedImage;
@@ -22,12 +22,13 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static qupath.ext.braian.BraiAnExtension.getLogger;
-import static qupath.ext.braian.BraiAnExtension.logger;
 
 class ImportedAtlasNotFound extends RuntimeException {
     public ImportedAtlasNotFound() {
@@ -37,20 +38,22 @@ class ImportedAtlasNotFound extends RuntimeException {
 
 class DisruptedAtlasHierarchy extends RuntimeException {
     public DisruptedAtlasHierarchy(PathObject atlas) {
-        super("The atlas hierarchy '"+atlas+"' was disrupted. "+
+        super("The atlas hierarchy '" + atlas + "' was disrupted. " +
                 "You must import the atlas annotations again and delete any previous region annotation.");
     }
 }
 
 class ExclusionMistakeException extends RuntimeException {
     public ExclusionMistakeException() {
-        super("Some regions in the atlas ontology were wrongly classified as '"+AtlasManager.EXCLUDE_CLASSIFICATION+"'.\n"+
+        super("Some regions in the atlas ontology were wrongly classified as '" + AtlasManager.EXCLUDE_CLASSIFICATION
+                + "'.\n" +
                 "You can try to fix this by calling fixExclusions() on the AtlasManager instance.");
     }
 }
 
 /**
- * This class helps to manage and exporting results for each brain region. It works closely with ABBA's QuPath extension.
+ * This class helps to manage and exporting results for each brain region. It
+ * works closely with ABBA's QuPath extension.
  */
 public class AtlasManager {
     public final static String um = GeneralTools.micrometerSymbol();
@@ -60,6 +63,7 @@ public class AtlasManager {
 
     /**
      * Checks whether at least one ABBA atlas was previously imported.
+     * 
      * @param hierarchy where to search for the atlas
      * @return true if an ABBA atlas was previously imported
      */
@@ -69,8 +73,10 @@ public class AtlasManager {
 
     /**
      * Checks whether a specific ABBA atlas was previously imported.
+     * 
      * @param atlasName the name of the atlas to check.
-     *                  If null, it checks whether <i>any</i> atlas was imported with ABBA
+     *                  If null, it checks whether <i>any</i> atlas was imported
+     *                  with ABBA
      * @param hierarchy where to search for the atlas
      * @return true if the atlas was previously imported
      */
@@ -82,8 +88,8 @@ public class AtlasManager {
         return hierarchy.getAnnotationObjects()
                 .stream()
                 .filter(o -> "Root".equals(o.getName()) &&
-                            (atlasName == null || (o.getPathClass() != null && o.getPathClass().getName().equals(atlasName)))
-                        )
+                        (atlasName == null
+                                || (o.getPathClass() != null && o.getPathClass().getName().equals(atlasName))))
                 .toList();
     }
 
@@ -92,28 +98,31 @@ public class AtlasManager {
                 Stream.of(parent),
                 parent.getChildObjects().stream()
                         .filter(o -> o instanceof PathAnnotationObject)
-                        .flatMap(AtlasManager::flattenObjectStream)
-        );
+                        .flatMap(AtlasManager::flattenObjectStream));
     }
 
     private static List<PathObject> flattenObject(PathObject parent) {
         return flattenObjectStream(parent).toList();
     }
 
-    private static List<String> getDetectionsMeasurements(List<AbstractDetections> detections) {
+    private static List<String> getDetectionsMeasurements(List<AbstractDetections> detections,
+                                                          ImageData<?> imageData) {
         // TODO: should avoid resorting to QP to get the server metadata
-        PixelCalibration cal = QP.getCurrentImageData().getServerMetadata().getPixelCalibration();
+        PixelCalibration cal = imageData.getServerMetadata().getPixelCalibration();
         if (!um.equals(cal.getPixelWidthUnit()) || !um.equals(cal.getPixelHeightUnit()))
-            throw new RuntimeException("FAILED to export results. Expected image pixel units to be in 'µm', instead got them in '"+
-                    cal.getPixelWidthUnit()+"' and '"+cal.getPixelWidthUnit()+"'. Try setting it with setPixelSizeMicrons()");
-        Stream<String> genericMeasurements = Stream.of("Name", "Classification", "Area "+um+"^2", "Num Detections");
-        Stream<String> detectionsMeasurements = detections.stream().flatMap(d -> d.getDetectionsPathClasses().stream().map(pc -> "Num "+pc.getName()));
+            throw new RuntimeException(
+                    "FAILED to export results. Expected image pixel units to be in 'µm', instead got them in '" +
+                            cal.getPixelWidthUnit() + "' and '" + cal.getPixelWidthUnit()
+                            + "'. Try setting it with setPixelSizeMicrons()");
+        Stream<String> genericMeasurements = Stream.of("Name", "Classification", "Area " + um + "^2", "Num Detections");
+        Stream<String> detectionsMeasurements = detections.stream()
+                .flatMap(d -> d.getDetectionsPathClasses().stream().map(pc -> "Num " + pc.getName()));
         return Stream.concat(genericMeasurements, detectionsMeasurements).toList();
     }
 
     private static List<PathObject> getExclusionAnnotations(PathObjectHierarchy hierarchy) {
         return hierarchy.getAnnotationObjects().stream()
-                .filter( ann -> ann.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION )
+                .filter(ann -> ann.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION)
                 .toList();
     }
 
@@ -122,10 +131,11 @@ public class AtlasManager {
 
     /**
      * Constructs a manager of the specified atlas imported with ABBA.
+     * 
      * @param atlasName the name of the atlas that was imported with ABBA.
      *                  If null, it selects the first available.
      * @param hierarchy where to search for the atlas
-     * @throws ImportedAtlasNotFound if the specified atlas was not found
+     * @throws ImportedAtlasNotFound   if the specified atlas was not found
      * @throws DisruptedAtlasHierarchy if the found atlas hierarchy was disrupted
      */
     public AtlasManager(String atlasName, PathObjectHierarchy hierarchy) {
@@ -136,14 +146,16 @@ public class AtlasManager {
         this.atlasObject = atlases.getFirst();
         if (this.atlasObject.getChildObjects().isEmpty())
             throw new DisruptedAtlasHierarchy(this.atlasObject);
-        if (atlases.size()>1)
+        if (atlases.size() > 1)
             getLogger().warn("Several imported atlases have been found. Selecting: {}", this.atlasObject);
     }
 
     /**
      * Constructs a manager of the first available atlas imported with ABBA.
+     * 
      * @param hierarchy where to search for an atlas
-     * @throws ImportedAtlasNotFound if no atlas was not found in the object hierarchy
+     * @throws ImportedAtlasNotFound   if no atlas was not found in the object
+     *                                 hierarchy
      * @throws DisruptedAtlasHierarchy if the found atlas hierarchy was disrupted
      * @see AtlasManager(String, PathObjectHierarchy)
      */
@@ -160,10 +172,13 @@ public class AtlasManager {
 
     /**
      * Flattens the atlas's ontology into a list of annotations.
-     * It may return some non-region annotations too, if the atlas hierarchy was modified with added/removed elements.
+     * It may return some non-region annotations too, if the atlas hierarchy was
+     * modified with added/removed elements.
+     * 
      * @return the list of all brain regions in the atlas
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      * @see #flatten(List)
      */
     public List<PathObject> flatten() {
@@ -174,13 +189,17 @@ public class AtlasManager {
 
     /**
      * Flattens the atlas ontology into a list of annotations.
-     * If the atlas hierarchy was modified by adding {@link AbstractDetections}'s containers,
+     * If the atlas hierarchy was modified by adding {@link AbstractDetections}'s
+     * containers,
      * it filters them from the current brain hierarchy.
      * <br>
-     * It may still return some non-region annotations, if the atlas hierarchy was further modified with added/removed elements.
+     * It may still return some non-region annotations, if the atlas hierarchy was
+     * further modified with added/removed elements.
+     * 
      * @return the list of all brain regions in the atlas
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      * @see #flatten()
      */
     public List<PathObject> flatten(List<AbstractDetections> detections) {
@@ -195,24 +214,47 @@ public class AtlasManager {
 
     /**
      * Saves a TSV file containing data for each brain region of the atlas.
-     * Namely, Image name, brain region name, hemisphere, area in µm², number of detections for each of the given types.
-     * The table is saved as a CSV (comma-separated values) file if 'file' ends with ".csv"
-     * @param detections the list of detection of which to gather the data for each region
-     * @param file the file where it should write to. Note that if the file exists, it will be overwritten
-     * @throws ExclusionMistakeException if the atlas hierarchy contains regions classified as {@link #EXCLUDE_CLASSIFICATION}.
-     * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     * Namely, Image name, brain region name, hemisphere, area in µm², number of
+     * detections for each of the given types.
+     * The table is saved as a CSV (comma-separated values) file if 'file' ends with
+     * ".csv"
+     * 
+     * @param detections the list of detection of which to gather the data for each
+     *                   region
+     * @param file       the file where it should write to. Note that if the file
+     *                   exists, it will be overwritten
+     * @throws ExclusionMistakeException if the atlas hierarchy contains regions
+     *                                   classified as
+     *                                   {@link #EXCLUDE_CLASSIFICATION}.
+     * @throws DisruptedAtlasHierarchy   if the current atlas hierarchy was
+     *                                   disrupted,
+     *                                   and it cannot find all the brain region
+     *                                   organised according to the atlas's
+     *                                   hierarchy
      */
-    // Olivier Burri <https://github.com/lacan> wrote mostly of this function and published under Apache-2.0 license for qupath-extension-biop
-    public boolean saveResults(List<AbstractDetections> detections, File file) {
+    // Olivier Burri <https://github.com/lacan> wrote mostly of this function and
+    // published under Apache-2.0 license for qupath-extension-biop
+    public boolean saveResults(List<AbstractDetections> detections,
+                               File file,
+                               ImageData<BufferedImage> imageData,
+                               ProjectImageEntry<BufferedImage> entry) {
         if (this.atlasObject.getChildObjects().isEmpty())
             throw new DisruptedAtlasHierarchy(this.atlasObject);
         if (file.exists())
-            if(!file.delete()) {
-                getLogger().error("Could not delete previous results file {}, the file could be locked.", file.getName());
+            if (!file.delete()) {
+                getLogger().error("Could not delete previous results file {}, the file could be locked.",
+                        file.getName());
                 return false;
             }
-        QP.mkdirs(file.getAbsoluteFile().getParent());
+        Path parent = file.toPath().getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                getLogger().error("Could not create directory {}: {}", parent, e.getMessage());
+                return false;
+            }
+        }
 
         // We use a ResultsTable to store the data
         ResultsTable results = new ResultsTable();
@@ -222,12 +264,12 @@ public class AtlasManager {
         if (brainRegions.stream().anyMatch(p -> p.getPathClass() == EXCLUDE_CLASSIFICATION))
             throw new ExclusionMistakeException();
         // This line creates all the measurements
-        ob.setImageData(QP.getCurrentImageData(), brainRegions);
+        if (imageData == null) {
+            throw new IllegalArgumentException("ImageData is required to export atlas results");
+        }
+        ob.setImageData(imageData, brainRegions);
 
-        ProjectImageEntry<BufferedImage> entry = QP.getProjectEntry();
-
-        assert entry != null;
-        String rawImageName = entry.getImageName();
+        String rawImageName = entry != null ? entry.getImageName() : imageData.getServerMetadata().getName();
         double numericValue;
 
         // Add value for each selected object
@@ -236,16 +278,17 @@ public class AtlasManager {
             results.addValue("Image Name", rawImageName);
 
             // Check if image has associated metadata and add it as columns
-            if (!entry.getMetadata().isEmpty()) {
+            if (entry != null && !entry.getMetadata().isEmpty()) {
                 Map<String, String> metadata = entry.getMetadata();
-                for(String key: metadata.keySet()) {
+                for (String key : metadata.keySet()) {
                     results.addValue("Metadata_" + key, metadata.get(key));
                 }
             }
 
             // Then we can add the results the user requested
-            // Because the Mu is sometimes poorly formatted, we remove them in favor of a 'u'
-            for (String col : AtlasManager.getDetectionsMeasurements(detections)) {
+            // Because the Mu is sometimes poorly formatted, we remove them in favor of a
+            // 'u'
+            for (String col : AtlasManager.getDetectionsMeasurements(detections, imageData)) {
                 if (ob.isNumericMeasurement(col)) {
                     numericValue = ob.getNumericValue(brainRegion, col);
                     if (col.startsWith("Num ") && Double.isNaN(numericValue))
@@ -257,14 +300,18 @@ public class AtlasManager {
             }
         }
         boolean isSaved = results.save(file.getAbsolutePath());
-        getLogger().info("Results '{}' Saved under '{}', contains {} rows", file.getName(), file.getParentFile().getAbsolutePath(), results.size());
+        getLogger().info("Results '{}' Saved under '{}', contains {} rows", file.getName(),
+                file.getParentFile().getAbsolutePath(), results.size());
         return isSaved;
     }
 
     /**
-     * Gets all the annotations that are covered by another annotation, classified as "Exclude"
+     * Gets all the annotations that are covered by another annotation, classified
+     * as "Exclude"
+     * 
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      */
     private Set<PathObject> getExcludedAnnotations() {
         if (this.atlasObject.getChildObjects().isEmpty())
@@ -272,27 +319,33 @@ public class AtlasManager {
         List<PathObject> excludeAnnotations = AtlasManager.getExclusionAnnotations(this.hierarchy);
         getLogger().info("Exclusion annotations: [{}]", BraiAn.join(excludeAnnotations, ", "));
         // We export all the annotations that are not "Exclude" or named "Root".
-        // This serves as a downstream ~check~ that the slice has nothing else other than the atlas annotations and the exclusions
+        // This serves as a downstream ~check~ that the slice has nothing else other
+        // than the atlas annotations and the exclusions
         var otherAnnotations = this.hierarchy.getAnnotationObjects().stream()
-                .filter( ann -> ann.getPathClass() != AtlasManager.EXCLUDE_CLASSIFICATION && ann != this.atlasObject)
+                .filter(ann -> ann.getPathClass() != AtlasManager.EXCLUDE_CLASSIFICATION && ann != this.atlasObject)
                 .toList();
         // Loop over exclusions that contain the annotations to be removed/excluded
         return excludeAnnotations.stream()
                 .map(exclusion -> exclusion.getROI().getGeometry())
-                .flatMap(exclusion -> otherAnnotations.stream().filter(ann -> ann.getROI().getGeometry().coveredBy(exclusion)))
+                .flatMap(exclusion -> otherAnnotations.stream()
+                        .filter(ann -> ann.getROI().getGeometry().coveredBy(exclusion)))
                 .collect(Collectors.toSet());
     }
 
     /**
-     * Gets all the brain regions that should be excluded from further analysis due to being missing or badly aligned to the image.
+     * Gets all the brain regions that should be excluded from further analysis due
+     * to being missing or badly aligned to the image.
      * A brain region, in order to be excluded, must:
      * <ul>
-     *   <li>either be contained into a larger annotation, classified as "Exclude"
-     * 	 <li>or be <b>duplicated</b> (SHIFT+D) outside the Atlas's hierarchy, and then classified as "Exclude"
+     * <li>either be contained into a larger annotation, classified as "Exclude"
+     * <li>or be <b>duplicated</b> (SHIFT+D) outside the Atlas's hierarchy, and then
+     * classified as "Exclude"
      * </ul>
+     * 
      * @return a set of brain regions' annotations that should be excluded.
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      */
     public Set<PathObject> getExcludedBrainRegions() {
         Set<PathObject> annotationsToExcludeFlattened = this.getExcludedAnnotations();
@@ -302,12 +355,13 @@ public class AtlasManager {
         Set<PathObject> weirdExcludedAnnotations = annotationsToExcludeFlattened.stream()
                 .filter(o -> !regionsToExcludeFlattened.contains(o)).collect(Collectors.toSet());
         if (!weirdExcludedAnnotations.isEmpty())
-            getLogger().error("Annotations excluded outside atlas ontology will be ignored. Make sure these annotations weren't meant to be classified as  '{}': [{}]",
+            getLogger().error(
+                    "Annotations excluded outside atlas ontology will be ignored. Make sure these annotations weren't meant to be classified as  '{}': [{}]",
                     EXCLUDE_CLASSIFICATION.toString(),
                     BraiAn.join(weirdExcludedAnnotations, ", "));
         // remove 'child' annotations that are descendant of an excluded parent
         var regionsToExclude = new HashSet<>(regionsToExcludeFlattened);
-        for (PathObject r1: regionsToExcludeFlattened) {
+        for (PathObject r1 : regionsToExcludeFlattened) {
             List<PathObject> descendants = AtlasManager.flattenObject(r1);
             for (PathObject r2 : regionsToExcludeFlattened)
                 if (descendants.indexOf(r2) > 0) // in 0 there is r1 itself, the parent annotation
@@ -317,11 +371,15 @@ public class AtlasManager {
     }
 
     /**
-     * Saves a file containing, on each line, the name and hemisphere of the regions to be excluded.
-     * @param file the file where it should write to. Note that if the file exists, it will be overwritten
+     * Saves a file containing, on each line, the name and hemisphere of the regions
+     * to be excluded.
+     * 
+     * @param file the file where it should write to. Note that if the file exists,
+     *             it will be overwritten
      * @return true if the file was correctly saved.
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      * @see #getExcludedBrainRegions()
      * @see #saveResults(List, File)
      */
@@ -329,13 +387,23 @@ public class AtlasManager {
         if (this.atlasObject.getChildObjects().isEmpty())
             throw new DisruptedAtlasHierarchy(this.atlasObject);
         if (file.exists())
-            if(!file.delete()) {
-                getLogger().error("Could not delete previous exclusion file {}, the file could be locked.", file.getName());
+            if (!file.delete()) {
+                getLogger().error("Could not delete previous exclusion file {}, the file could be locked.",
+                        file.getName());
                 return false;
             }
-        QP.mkdirs(file.getAbsoluteFile().getParent());
+        Path parent = file.toPath().getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                getLogger().error("Could not create directory {}: {}", parent, e.getMessage());
+                return false;
+            }
+        }
 
-        Set<PathObject> regionsToExcludeSet = this.getExcludedBrainRegions(); // NOTE: may return things that aren't brain regions
+        Set<PathObject> regionsToExcludeSet = this.getExcludedBrainRegions(); // NOTE: may return things that aren't
+                                                                              // brain regions
 
         List<PathObject> regionsToExclude = regionsToExcludeSet.stream()
                 .filter(o -> o.getPathClass() != null)
@@ -343,8 +411,10 @@ public class AtlasManager {
                 .toList();
         getLogger().info("Excluded regions: [{}]", BraiAn.join(regionsToExclude, ", "));
 
-        QP.resetSelection();
-        QP.selectObjects(regionsToExclude);
+        this.hierarchy.getSelectionModel().clearSelection();
+        if (!regionsToExclude.isEmpty()) {
+            this.hierarchy.getSelectionModel().setSelectedObjects(regionsToExclude, null);
+        }
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
             for (PathObject region : regionsToExclude) {
@@ -355,17 +425,23 @@ public class AtlasManager {
             getLogger().error("Error saving excluded regions: {}", e.getMessage());
             return false;
         }
-        getLogger().info("Exclusions '{}' Saved under '{}', contains {} rows", file.getName(), file.getParentFile().getAbsolutePath(), regionsToExclude.size());
+        getLogger().info("Exclusions '{}' Saved under '{}', contains {} rows", file.getName(),
+                file.getParentFile().getAbsolutePath(), regionsToExclude.size());
         return true;
     }
 
     /**
      * Return whether the current atlas is split between left and right hemispheres.
-     * Atlas hierarchies that were modified by deleting one of the two hemispheres, are still recognised as split.
-     * @return true if the current atlas is split between left and right hemispheres.
+     * Atlas hierarchies that were modified by deleting one of the two hemispheres,
+     * are still recognised as split.
+     * 
+     * @return true if the current atlas is split between left and right
+     *         hemispheres.
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
-     * whether the atlas was split between left and right.
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
+     *                                 whether the atlas was split between left and
+     *                                 right.
      */
     public boolean isSplit() {
         if (this.atlasObject.getChildObjects().isEmpty())
@@ -376,33 +452,35 @@ public class AtlasManager {
         return roots.stream()
                 // anyMatch because if there are multiple "root" annotations, an
                 .anyMatch(root -> {
-                            Set<PathClass> hemispheres = flattenObject(root).stream()
-                                    .map(PathObject::getPathClass)
-                                    .filter(c -> c.isDerivedFrom(ABBA_LEFT) || c.isDerivedFrom(ABBA_RIGHT))
-                                    .map(PathClass::getParentClass)
-                                    .collect(Collectors.toSet());
-                            if (hemispheres.size() == 2)
-                                throw new DisruptedAtlasHierarchy(this.atlasObject);
-                            return hemispheres.size() == 1;
-                        }
-                );
+                    Set<PathClass> hemispheres = flattenObject(root).stream()
+                            .map(PathObject::getPathClass)
+                            .filter(c -> c.isDerivedFrom(ABBA_LEFT) || c.isDerivedFrom(ABBA_RIGHT))
+                            .map(PathClass::getParentClass)
+                            .collect(Collectors.toSet());
+                    if (hemispheres.size() == 2)
+                        throw new DisruptedAtlasHierarchy(this.atlasObject);
+                    return hemispheres.size() == 1;
+                });
     }
 
     /**
      * Attempts to fix possible mistakes with the exclusions, such as:
-     *  <ul>
-     *   <li>Exclusion of the "Root" hierarchy annotation rather than a proper region</li>
-     *   <li>If a region was excluded within the atlas hierarchy</li>
-     *   <li>If a region's classifications was removed</li>
+     * <ul>
+     * <li>Exclusion of the "Root" hierarchy annotation rather than a proper
+     * region</li>
+     * <li>If a region was excluded within the atlas hierarchy</li>
+     * <li>If a region's classifications was removed</li>
      * </ul>
+     * 
      * @throws DisruptedAtlasHierarchy if the current atlas hierarchy was disrupted,
-     * and it cannot find all the brain region organised according to the atlas's hierarchy
+     *                                 and it cannot find all the brain region
+     *                                 organised according to the atlas's hierarchy
      */
     public void fixExclusions() {
         if (this.atlasObject.getChildObjects().isEmpty())
             throw new DisruptedAtlasHierarchy(this.atlasObject);
         if (this.atlasObject.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION) {
-            for (PathObject root: this.atlasObject.getChildObjects()) {
+            for (PathObject root : this.atlasObject.getChildObjects()) {
                 PathObject duplicate = PathObjectTools.transformObject(root, null, true, true);
                 duplicate.setPathClass(AtlasManager.EXCLUDE_CLASSIFICATION);
                 this.hierarchy.addObject(duplicate);
@@ -411,32 +489,32 @@ public class AtlasManager {
         }
         this.flatten().stream()
                 .filter(
-                        region ->
-                                        (region.getPathClass() != null && region.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION) ||
-                                        (region.getPathClass() == null && region != this.atlasObject)
-                ).forEach(
-                        mistakenlyExcludedRegion -> this.fixMistakenlyExcludedRegion(mistakenlyExcludedRegion, this.isSplit())
-                );
+                        region -> (region.getPathClass() != null
+                                && region.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION) ||
+                                (region.getPathClass() == null && region != this.atlasObject))
+                .forEach(
+                        mistakenlyExcludedRegion -> this.fixMistakenlyExcludedRegion(mistakenlyExcludedRegion,
+                                this.isSplit()));
     }
 
     private void fixMistakenlyExcludedRegion(PathObject mistakenlyExcludedRegion, boolean isSplit) {
         String regionName;
         if ((regionName = mistakenlyExcludedRegion.getName()) == null)
-            throw new RuntimeException("Can't deduce the name for brain region '"+mistakenlyExcludedRegion+"'.");
+            throw new RuntimeException("Can't deduce the name for brain region '" + mistakenlyExcludedRegion + "'.");
         PathClass classification;
         if (isSplit)
-            classification = PathClass.getInstance(this.getHemisphereOfMisclassifiedRegion(mistakenlyExcludedRegion),  regionName, null);
+            classification = PathClass.getInstance(this.getHemisphereOfMisclassifiedRegion(mistakenlyExcludedRegion),
+                    regionName, null);
         else
             classification = PathClass.fromString(regionName);
         List<PathObject> wrongDuplicates = this.hierarchy.getRootObject().getChildObjects().stream().filter(
-            ann -> regionName.equals(ann.getName()) && ann.getPathClass() == classification
-        ).toList();
+                ann -> regionName.equals(ann.getName()) && ann.getPathClass() == classification).toList();
         if (wrongDuplicates.isEmpty()) {
             PathObject duplicate = PathObjectTools.transformObject(mistakenlyExcludedRegion, null, true, true);
             this.hierarchy.addObject(duplicate);
             wrongDuplicates = List.of(duplicate);
         }
-        for (PathObject wrongDuplicate: wrongDuplicates) {
+        for (PathObject wrongDuplicate : wrongDuplicates) {
             wrongDuplicate.setPathClass(AtlasManager.EXCLUDE_CLASSIFICATION);
         }
         mistakenlyExcludedRegion.setPathClass(classification);
@@ -448,11 +526,12 @@ public class AtlasManager {
             hemisphereObject = hemisphereObject.getParent();
         Set<PathClass> hemisphere = flattenObject(hemisphereObject).stream()
                 .map(PathObject::getPathClass)
-                .filter(c -> c != null && c.isDerivedClass() && (c.isDerivedFrom(ABBA_LEFT) || c.isDerivedFrom(ABBA_RIGHT)))
+                .filter(c -> c != null && c.isDerivedClass()
+                        && (c.isDerivedFrom(ABBA_LEFT) || c.isDerivedFrom(ABBA_RIGHT)))
                 .map(PathClass::getParentClass)
                 .collect(Collectors.toSet());
         if (hemisphere.size() != 1)
-            throw new RuntimeException("Can't deduce the hemisphere for '"+region+"'.");
+            throw new RuntimeException("Can't deduce the hemisphere for '" + region + "'.");
         return hemisphere.iterator().next();
     }
 }

--- a/src/main/java/qupath/ext/braian/ChannelDetections.java
+++ b/src/main/java/qupath/ext/braian/ChannelDetections.java
@@ -5,7 +5,7 @@
 package qupath.ext.braian;
 
 import qupath.ext.braian.config.WatershedCellDetectionConfig;
-import qupath.lib.common.GsonTools;
+import qupath.lib.io.GsonTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;

--- a/src/main/java/qupath/ext/braian/ChannelDetections.java
+++ b/src/main/java/qupath/ext/braian/ChannelDetections.java
@@ -5,12 +5,22 @@
 package qupath.ext.braian;
 
 import qupath.ext.braian.config.WatershedCellDetectionConfig;
+import qupath.lib.common.GsonTools;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.images.ImageData;
+import qupath.lib.images.servers.ImageServer;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
-import qupath.lib.scripting.QP;
+import qupath.lib.plugins.CommandLineTaskRunner;
+import qupath.lib.plugins.PathPlugin;
+import qupath.lib.projects.Project;
+import qupath.lib.regions.ImagePlane;
+import qupath.lib.roi.ROIs;
 
+import java.lang.reflect.Constructor;
 import java.util.*;
 
 /**
@@ -25,12 +35,16 @@ public class ChannelDetections extends AbstractDetections {
      * @param hierarchy where to find/compute the detections
      * @return the full image detection named as {@link ChannelDetections#FULL_IMAGE_DETECTIONS_NAME}
      */
-    public static PathAnnotationObject getFullImageDetectionAnnotation(PathObjectHierarchy hierarchy) {
+    public static PathAnnotationObject getFullImageDetectionAnnotation(ImageData<?> imageData,
+                                                                       PathObjectHierarchy hierarchy) {
+        if (imageData == null) {
+            throw new IllegalArgumentException("ImageData is required to create a full image annotation");
+        }
         List<PathObject> fullImageAnnotations = hierarchy.getAnnotationObjects().stream()
                 .filter(a -> FULL_IMAGE_DETECTIONS_NAME.equals(a.getName())).toList();
         switch (fullImageAnnotations.size()) {
             case 0:
-                PathAnnotationObject fullImageAnnotation = (PathAnnotationObject) QP.createFullImageAnnotation(true);
+                PathAnnotationObject fullImageAnnotation = createFullImageAnnotation(imageData, hierarchy, true);
                 fullImageAnnotation.setName(FULL_IMAGE_DETECTIONS_NAME);
                 return fullImageAnnotation;
             case 1:
@@ -53,8 +67,11 @@ public class ChannelDetections extends AbstractDetections {
      * @see #getContainersName()
      * @see AbstractDetections
      */
-    public ChannelDetections(String channelName, PathObjectHierarchy hierarchy) throws NoCellContainersFoundException {
-        super(channelName, List.of(createClassification(channelName)), hierarchy);
+    public ChannelDetections(String channelName,
+                             PathObjectHierarchy hierarchy,
+                             Project<?> project,
+                             QuPathGUI qupath) throws NoCellContainersFoundException {
+        super(channelName, List.of(createClassification(channelName)), hierarchy, project, qupath);
     }
 
     /**
@@ -66,8 +83,11 @@ public class ChannelDetections extends AbstractDetections {
      * @see #getContainersName()
      * @see AbstractDetections
      */
-    public ChannelDetections(ImageChannelTools channel, PathObjectHierarchy hierarchy) throws NoCellContainersFoundException {
-        this(channel.getName(), hierarchy);
+    public ChannelDetections(ImageChannelTools channel,
+                             PathObjectHierarchy hierarchy,
+                             Project<?> project,
+                             QuPathGUI qupath) throws NoCellContainersFoundException {
+        this(channel.getName(), hierarchy, project, qupath);
     }
 
     /**
@@ -82,11 +102,14 @@ public class ChannelDetections extends AbstractDetections {
     public ChannelDetections(ImageChannelTools channel,
                              Collection<PathAnnotationObject> annotations,
                              WatershedCellDetectionConfig config,
-                             PathObjectHierarchy hierarchy) throws NoCellContainersFoundException {
-        this(channel, hierarchy);
+                             PathObjectHierarchy hierarchy,
+                             ImageData<?> imageData,
+                             Project<?> project,
+                             QuPathGUI qupath) throws NoCellContainersFoundException {
+        this(channel, hierarchy, project, qupath);
 
         if(annotations == null) {
-            PathAnnotationObject fullImage = ChannelDetections.getFullImageDetectionAnnotation(hierarchy);
+            PathAnnotationObject fullImage = ChannelDetections.getFullImageDetectionAnnotation(imageData, hierarchy);
             annotations = List.of(fullImage);
         } else if (annotations.isEmpty()) {
             throw new IllegalArgumentException("You must give at least one annotation on which to compute the detections");
@@ -96,7 +119,7 @@ public class ChannelDetections extends AbstractDetections {
         List<PathAnnotationObject> containers = annotations.stream().map(annotation -> {
             annotation.setLocked(true);
             PathAnnotationObject container = this.createContainer(annotation, true);
-            return ChannelDetections.compute(container, params);
+            return ChannelDetections.compute(container, params, imageData);
         }).toList();
 
         this.fireUpdate();
@@ -114,19 +137,71 @@ public class ChannelDetections extends AbstractDetections {
     public ChannelDetections(ImageChannelTools channel,
                              PathAnnotationObject annotation,
                              WatershedCellDetectionConfig config,
-                             PathObjectHierarchy hierarchy) throws NoCellContainersFoundException {
-        this(channel, annotation != null ? List.of(annotation) : null, config, hierarchy);
+                             PathObjectHierarchy hierarchy,
+                             ImageData<?> imageData,
+                             Project<?> project,
+                             QuPathGUI qupath) throws NoCellContainersFoundException {
+        this(channel,
+                annotation != null ? List.of(annotation) : null,
+                config,
+                hierarchy,
+                imageData,
+                project,
+                qupath);
     }
 
-    private static PathAnnotationObject compute(PathAnnotationObject container, Map<String,?> params) {
-        QP.selectObjects(container);
+    private static PathAnnotationObject compute(PathAnnotationObject container,
+                                                Map<String,?> params,
+                                                ImageData<?> imageData) {
+        if (imageData == null) {
+            throw new IllegalArgumentException("ImageData is required to run cell detection");
+        }
+        imageData.getHierarchy().getSelectionModel().setSelectedObject(container);
         try {
-            QP.runPlugin("qupath.imagej.detect.cells.WatershedCellDetection", params);
+            runPlugin("qupath.imagej.detect.cells.WatershedCellDetection", imageData, params);
             ChannelDetections.getChildrenDetections(container).forEach(detection -> detection.setPathClass(container.getPathClass()));
             return container;
         } catch (InterruptedException e) {
             BraiAnExtension.logger.warn("Watershed cell detection interrupted. Returning empty list of detections for "+container+"!");
             return container;
+        }
+    }
+
+    private static PathAnnotationObject createFullImageAnnotation(ImageData<?> imageData,
+                                                                  PathObjectHierarchy hierarchy,
+                                                                  boolean setSelected) {
+        ImageServer<?> server = imageData.getServer();
+        PathObject pathObject = PathObjects.createAnnotationObject(
+                ROIs.createRectangleROI(0, 0, server.getWidth(), server.getHeight(), ImagePlane.getPlane(0, 0))
+        );
+        hierarchy.addObject(pathObject);
+        if (setSelected) {
+            hierarchy.getSelectionModel().setSelectedObject(pathObject);
+        }
+        return (PathAnnotationObject) pathObject;
+    }
+
+    private static boolean runPlugin(final String className,
+                                     final ImageData<?> imageData,
+                                     final Map<String, ?> args) throws InterruptedException {
+        var json = args == null ? "" : GsonTools.getInstance().toJson(args);
+        return runPlugin(className, imageData, json);
+    }
+
+    private static boolean runPlugin(final String className,
+                                     final ImageData<?> imageData,
+                                     final String args) throws InterruptedException {
+        if (imageData == null)
+            return false;
+
+        try {
+            Class<?> cPlugin = ChannelDetections.class.getClassLoader().loadClass(className);
+            Constructor<?> cons = cPlugin.getConstructor();
+            final PathPlugin plugin = (PathPlugin) cons.newInstance();
+            return plugin.runPlugin(new CommandLineTaskRunner(), imageData, args);
+        } catch (Exception e) {
+            BraiAnExtension.logger.error("Unable to run plugin {}", className, e);
+            return false;
         }
     }
 

--- a/src/main/java/qupath/ext/braian/ImageChannelTools.java
+++ b/src/main/java/qupath/ext/braian/ImageChannelTools.java
@@ -25,6 +25,15 @@ class IllegalChannelName extends RuntimeException {
     }
 }
 
+/**
+ * Utility helper to access and process a named image channel.
+ * <p>
+ * This class bridges QuPath channel metadata and ImageJ processors, and is used to compute
+ * per-channel histograms/statistics and retrieve existing detections.
+ *
+ * @see ChannelHistogram
+ * @see ChannelDetections
+ */
 public class ImageChannelTools {
     private final String name;
     private final ImageData<BufferedImage> imageData;
@@ -149,6 +158,6 @@ public class ImageChannelTools {
      * @see ChannelDetections
      */
     public ChannelDetections getDetections(PathObjectHierarchy hierarchy) throws NoCellContainersFoundException {
-        return new ChannelDetections(this, hierarchy);
+        return new ChannelDetections(this, hierarchy, null, null);
     }
 }

--- a/src/main/java/qupath/ext/braian/ImageChannelTools.java
+++ b/src/main/java/qupath/ext/braian/ImageChannelTools.java
@@ -25,15 +25,6 @@ class IllegalChannelName extends RuntimeException {
     }
 }
 
-/**
- * Utility helper to access and process a named image channel.
- * <p>
- * This class bridges QuPath channel metadata and ImageJ processors, and is used to compute
- * per-channel histograms/statistics and retrieve existing detections.
- *
- * @see ChannelHistogram
- * @see ChannelDetections
- */
 public class ImageChannelTools {
     private final String name;
     private final ImageData<BufferedImage> imageData;

--- a/src/main/java/qupath/ext/braian/OverlappingDetections.java
+++ b/src/main/java/qupath/ext/braian/OverlappingDetections.java
@@ -9,6 +9,8 @@ import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.projects.Project;
 import qupath.lib.roi.interfaces.ROI;
 
 import java.util.Collection;
@@ -72,7 +74,16 @@ public class OverlappingDetections extends AbstractDetections {
     public OverlappingDetections(AbstractDetections control,
                                  Collection<AbstractDetections> others,
                                  boolean compute, PathObjectHierarchy hierarchy) throws NoCellContainersFoundException {
-        super(control.getId(), getAllPossibleOverlappingClassifications(control, others), hierarchy);
+        this(control, others, compute, hierarchy, null, null);
+    }
+
+    public OverlappingDetections(AbstractDetections control,
+                                 Collection<AbstractDetections> others,
+                                 boolean compute,
+                                 PathObjectHierarchy hierarchy,
+                                 Project<?> project,
+                                 QuPathGUI qupath) throws NoCellContainersFoundException {
+        super(control.getId(), getAllPossibleOverlappingClassifications(control, others), hierarchy, project, qupath);
         if (!compute)
             return;
         this.overlap(control, others);
@@ -89,7 +100,15 @@ public class OverlappingDetections extends AbstractDetections {
     public OverlappingDetections(AbstractDetections control,
                                  Collection<AbstractDetections> others,
                                  PathObjectHierarchy hierarchy) throws NoCellContainersFoundException {
-        this(control, others, false, hierarchy);
+        this(control, others, false, hierarchy, null, null);
+    }
+
+    public OverlappingDetections(AbstractDetections control,
+                                 Collection<AbstractDetections> others,
+                                 PathObjectHierarchy hierarchy,
+                                 Project<?> project,
+                                 QuPathGUI qupath) throws NoCellContainersFoundException {
+        this(control, others, false, hierarchy, project, qupath);
     }
 
     @Override

--- a/src/main/java/qupath/ext/braian/config/ChannelClassifierConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ChannelClassifierConfig.java
@@ -14,13 +14,12 @@ import qupath.lib.io.UriResource;
 import qupath.lib.io.UriUpdater;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+import qupath.lib.projects.Project;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-
-import static qupath.lib.scripting.QP.getProject;
 
 public class ChannelClassifierConfig {
     private String channel;
@@ -63,10 +62,10 @@ public class ChannelClassifierConfig {
      * @throws IOException if any problem raises when reading the JSON file, supposedly corresponding to a QuPath
      * object classifier.
      */
-    public <T> ObjectClassifier<T> loadClassifier() throws IOException {
+    public <T> ObjectClassifier<T> loadClassifier(Project<?> project) throws IOException {
         if (this.getName().equalsIgnoreCase("all"))
             return new SingleClassifier<>(ChannelDetections.createClassification(this.channel));
-        Path classifierPath = BraiAn.resolvePath(this.getName()+".json");
+        Path classifierPath = BraiAn.resolvePath(project, this.getName() + ".json");
         // inspired by QP.loadObjectClassifier()
         ObjectClassifier<T> classifier = null;
         Exception exception = null;
@@ -78,8 +77,8 @@ public class ChannelClassifierConfig {
             throw new IOException("Unable to find object classifier " + classifierPath, exception);
 
         // Try to fix URIs, if we can
-        if (classifier instanceof UriResource)
-            UriUpdater.fixUris((UriResource)classifier, getProject());
+        if (classifier instanceof UriResource && project != null)
+            UriUpdater.fixUris((UriResource) classifier, project);
 
         return classifier;
     }
@@ -107,8 +106,8 @@ public class ChannelClassifierConfig {
      * @see ChannelClassifierConfig#loadClassifier()
      * @see ChannelClassifierConfig#getAnnotationsToClassify()
      */
-    public <T> PartialClassifier<T> toPartialClassifier(PathObjectHierarchy hierarchy) throws IOException {
-        ObjectClassifier<T> classifier = this.loadClassifier();
+    public <T> PartialClassifier<T> toPartialClassifier(PathObjectHierarchy hierarchy, Project<?> project) throws IOException {
+        ObjectClassifier<T> classifier = this.loadClassifier(project);
         return new PartialClassifier<>(classifier, this.getAnnotationsToClassify(hierarchy));
     }
 }

--- a/src/main/java/qupath/ext/braian/config/ProjectsConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ProjectsConfig.java
@@ -5,10 +5,14 @@
 package qupath.ext.braian.config;
 
 import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
-import qupath.ext.braian.BraiAnExtension;
+import org.yaml.snakeyaml.introspector.BeanAccess;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.introspector.PropertyUtils;
+import org.yaml.snakeyaml.representer.Representer;
 import qupath.ext.braian.utils.BraiAn;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
@@ -24,21 +28,33 @@ import java.util.Optional;
 import static qupath.ext.braian.BraiAnExtension.getLogger;
 
 /**
- * This class reads a YAML file and can be used to apply the given parameters to the computation offered by BraiAn extension
- * For more information, read <a href="https://github.com/carlocastoldi/qupath-extension-braian/blob/master/BraiAn.yml">this config file example</a>.
+ * This class reads a YAML file and can be used to apply the given parameters to
+ * the computation offered by BraiAn extension
+ * For more information, read <a href=
+ * "https://github.com/carlocastoldi/qupath-extension-braian/blob/master/BraiAn.yml">this
+ * config file example</a>.
  */
 public class ProjectsConfig {
     /**
      * Reads a BraiAn configuration file
+     * 
      * @param yamlFileName the name of the file, not the path.
-     *                     It will then search it first into the project's directory and, if it wasn't there, in its parent directory.
-     *                     If it cannot still find it, it throws {@link java.io.FileNotFoundException}
+     *                     It will then search it first into the project's directory
+     *                     and, if it wasn't there, in its parent directory.
+     *                     If it cannot still find it, it throws
+     *                     {@link java.io.FileNotFoundException}
      * @return an instance of <code>ProjectsConfig</code>
-     * @throws IOException if it found the config file, but it had problems while reading it.
-     * @throws YAMLException if it found and read the config file, but it was badly formatted.
+     * @throws IOException   if it found the config file, but it had problems while
+     *                       reading it.
+     * @throws YAMLException if it found and read the config file, but it was badly
+     *                       formatted.
      */
     public static ProjectsConfig read(String yamlFileName) throws IOException, YAMLException {
         Path filePath = BraiAn.resolvePath(yamlFileName);
+        return read(filePath);
+    }
+
+    public static ProjectsConfig read(Path filePath) throws IOException, YAMLException {
         getLogger().info("using '{}' configuration file.", filePath);
         String configStream = Files.readString(filePath, StandardCharsets.UTF_8);
 
@@ -46,12 +62,41 @@ public class ProjectsConfig {
             Constructor c = new Constructor(ProjectsConfig.class, new LoaderOptions());
             return new Yaml(c).load(configStream);
         } catch (YAMLException e) {
-            getLogger().error("Could not interpret the file '{}'. Please check that it is correctly formatted!", filePath);
+            getLogger().error("Could not interpret the file '{}'. Please check that it is correctly formatted!",
+                    filePath);
             throw e;
         }
     }
 
+    public static String toYaml(ProjectsConfig config) {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        options.setIndent(2);
+        options.setIndicatorIndent(0);
+        options.setDefaultScalarStyle(DumperOptions.ScalarStyle.PLAIN);
+
+        Representer representer = new Representer(options);
+        PropertyUtils propertyUtils = new PropertyUtils() {
+            @Override
+            protected java.util.Set<Property> createPropertySet(Class<?> type, BeanAccess bAccess) {
+                var properties = super.createPropertySet(type, bAccess);
+                if (type == WatershedCellDetectionConfig.class) {
+                    properties.removeIf(property -> "detectionImage".equals(property.getName()));
+                }
+                return properties;
+            }
+        };
+        propertyUtils.setSkipMissingProperties(true);
+        representer.setPropertyUtils(propertyUtils);
+        representer.getPropertyUtils().setSkipMissingProperties(true);
+
+        Yaml yaml = new Yaml(representer, options);
+        return yaml.dumpAsMap(config);
+    }
+
     private String classForDetections = null;
+    private String atlasName = "allen_mouse_10um_java";
     private DetectionsCheckConfig detectionsCheck = new DetectionsCheckConfig();
     private List<ChannelDetectionsConfig> channelDetections = List.of();
 
@@ -59,27 +104,39 @@ public class ProjectsConfig {
         return classForDetections;
     }
 
+    public void setClassForDetections(String classForDetections) {
+        this.classForDetections = classForDetections;
+    }
+
     /**
-     * Finds (or creates) the annotations chosen for computing the detections, accordingly to the configuration file.
-     * It reads the value of 'classForDetections' in the YAML and searches all annotations having the appointed classification
+     * Finds (or creates) the annotations chosen for computing the detections,
+     * accordingly to the configuration file.
+     * It reads the value of 'classForDetections' in the YAML and searches all
+     * annotations having the appointed classification
+     * 
      * @param hierarchy where to search the annotations in
      * @return the annotations to be used for computing the detections
      * @see qupath.ext.braian.ChannelDetections
      */
     public Collection<PathAnnotationObject> getAnnotationsForDetections(PathObjectHierarchy hierarchy) {
         String classForDetections = this.getClassForDetections();
-        if(classForDetections == null)
+        if (classForDetections == null)
             return null;
         return hierarchy.getAnnotationObjects()
                 .stream()
-                .filter(annotation -> annotation.getPathClass() != null && classForDetections.equals(annotation.getPathClass().getName()))
-                //.filter(annotation -> classForDetections.equals(annotation.getName()))
+                .filter(annotation -> annotation.getPathClass() != null
+                        && classForDetections.equals(annotation.getPathClass().getName()))
+                // .filter(annotation -> classForDetections.equals(annotation.getName()))
                 .map(annotation -> (PathAnnotationObject) annotation)
                 .toList();
     }
 
-    public void setClassForDetections(String classForDetections) {
-        this.classForDetections = classForDetections;
+    public String getAtlasName() {
+        return atlasName;
+    }
+
+    public void setAtlasName(String atlasName) {
+        this.atlasName = atlasName;
     }
 
     public DetectionsCheckConfig getDetectionsCheck() {
@@ -92,15 +149,19 @@ public class ProjectsConfig {
 
     /**
      * Retrieves the name of the channel to be used as control in the overlapping
-     * @return an empty optional if no overlapping is desired or if there there is only one image channel to compute the detections for
+     * 
+     * @return an empty optional if no overlapping is desired or if there there is
+     *         only one image channel to compute the detections for
      * @see qupath.ext.braian.OverlappingDetections
      */
     public Optional<String> getControlChannel() {
-        if (!this.detectionsCheck.getApply() || this.channelDetections.size() < 2) // if there is only one channel with detections, it is useless to have a controlChannel
+        if (!this.detectionsCheck.getApply() || this.channelDetections.size() < 2) // if there is only one channel with
+                                                                                   // detections, it is useless to have
+                                                                                   // a controlChannel
             return Optional.empty();
         String name = this.detectionsCheck.getControlChannel();
         if (name == null)
-            name =  this.channelDetections.get(0).getName();
+            name = this.channelDetections.get(0).getName();
         return Optional.of(name);
     }
 

--- a/src/main/java/qupath/ext/braian/config/ProjectsConfig.java
+++ b/src/main/java/qupath/ext/braian/config/ProjectsConfig.java
@@ -16,6 +16,7 @@ import org.yaml.snakeyaml.representer.Representer;
 import qupath.ext.braian.utils.BraiAn;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+import qupath.lib.projects.Project;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -49,8 +50,8 @@ public class ProjectsConfig {
      * @throws YAMLException if it found and read the config file, but it was badly
      *                       formatted.
      */
-    public static ProjectsConfig read(String yamlFileName) throws IOException, YAMLException {
-        Path filePath = BraiAn.resolvePath(yamlFileName);
+    public static ProjectsConfig read(Project<?> project, String yamlFileName) throws IOException, YAMLException {
+        Path filePath = BraiAn.resolvePath(project, yamlFileName);
         return read(filePath);
     }
 

--- a/src/main/java/qupath/ext/braian/utils/BraiAn.java
+++ b/src/main/java/qupath/ext/braian/utils/BraiAn.java
@@ -7,6 +7,7 @@ package qupath.ext.braian.utils;
 import qupath.fx.utils.FXUtils;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.objects.classes.PathClass;
+import qupath.lib.projects.Project;
 import qupath.lib.projects.Projects;
 
 import java.io.FileNotFoundException;
@@ -14,14 +15,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
-import static qupath.lib.scripting.QP.getProject;
-
 public class BraiAn {
-    public static Optional<Path> resolvePathIfPresent(String fileName) {
-        Path projectPath = Projects.getBaseDirectory(getProject()).toPath();
+    public static Optional<Path> resolvePathIfPresent(Project<?> project, String fileName) {
+        if (project == null) {
+            return Optional.empty();
+        }
+        Path projectPath = Projects.getBaseDirectory(project).toPath();
         Path projectParentDirectoryPath = projectPath.getParent();
-        Path[] resolutionOrder = {projectPath, projectParentDirectoryPath};
-        for (Path path: resolutionOrder) {
+        Path[] resolutionOrder = { projectPath, projectParentDirectoryPath };
+        for (Path path : resolutionOrder) {
+            if (path == null)
+                continue;
             Path filePath = path.resolve(fileName);
             if (Files.exists(filePath))
                 return Optional.of(filePath);
@@ -30,29 +34,38 @@ public class BraiAn {
     }
 
     /**
-     * It searches for a file accordingly to BraiAn specifics: it first searches it in the project's path;
-     * if it is not present, it searches it in the parent directory, were supposedly other QuPath projects of the
+     * It searches for a file accordingly to BraiAn specifics: it first searches it
+     * in the project's path;
+     * if it is not present, it searches it in the parent directory, were supposedly
+     * other QuPath projects of the
      * same experiment reside.
+     * 
      * @param fileName the name of the file to search accordingly to BraiAn
      * @return the complete path to <code>fileName</code>.
-     * @throws FileNotFoundException if no file named <code>fileName</code> was found.
+     * @throws FileNotFoundException if no file named <code>fileName</code> was
+     *                               found.
      */
-    public static Path resolvePath(String fileName) throws FileNotFoundException {
-        return resolvePathIfPresent(fileName)
-                .orElseThrow(() -> new FileNotFoundException("Can't find the specified file: '"+fileName+"'"));
+    public static Path resolvePath(Project<?> project, String fileName) throws FileNotFoundException {
+        return resolvePathIfPresent(project, fileName)
+                .orElseThrow(() -> new FileNotFoundException("Can't find the specified file: '" + fileName + "'"));
     }
 
-    public static void populatePathClassGUI(PathClass... toAdd) {
-        List<PathClass> visibleClasses = new ArrayList<>(getProject().getPathClasses());
+    public static void populatePathClassGUI(Project<?> project, QuPathGUI qupath, PathClass... toAdd) {
+        if (project == null || toAdd == null || toAdd.length == 0) {
+            return;
+        }
+        List<PathClass> visibleClasses = new ArrayList<>(project.getPathClasses());
         List<PathClass> missingClasses = Arrays.stream(toAdd)
                 .filter(classification -> !visibleClasses.contains(classification))
                 .toList();
+        if (missingClasses.isEmpty()) {
+            return;
+        }
         visibleClasses.addAll(missingClasses);
-        var qupathGUI = QuPathGUI.getInstance();
-        if (qupathGUI != null)
-            FXUtils.runOnApplicationThread(() ->
-                qupathGUI.getAvailablePathClasses().setAll(visibleClasses)
-            );
+        project.setPathClasses(visibleClasses);
+        if (qupath != null) {
+            FXUtils.runOnApplicationThread(() -> qupath.getAvailablePathClasses().setAll(visibleClasses));
+        }
     }
 
     public static <T> String join(Collection<T> c, String delimiter) {
@@ -60,11 +73,11 @@ public class BraiAn {
             return "";
         StringBuilder classesStr = new StringBuilder();
         List<T> l = c instanceof List ? (List<T>) c : new ArrayList<>(c);
-        for (int i = 0; i < l.size()-1; i++) {
+        for (int i = 0; i < l.size() - 1; i++) {
             T o = l.get(i);
             classesStr.append(o).append(delimiter);
         }
-        classesStr.append(l.get(l.size()-1));
+        classesStr.append(l.get(l.size() - 1));
         return classesStr.toString();
     }
 }

--- a/src/main/resources/scripts/compute_classify_overlap_export_exclude_detections.groovy
+++ b/src/main/resources/scripts/compute_classify_overlap_export_exclude_detections.groovy
@@ -86,7 +86,7 @@ if (AtlasManager.isImported(atlasName, hierarchy)) {
     def imageName = getProjectEntry().getImageName().replaceAll(invalid_chars_regex, '')
 
     var resultsFile = new File(buildPathInProject("results", imageName + "_regions.tsv")) // can be .csv too
-    atlas.saveResults(allDetections + overlaps, resultsFile)
+    atlas.saveResults(allDetections + overlaps, resultsFile, imageData, getProjectEntry())
 
     def exclusionsFile = new File(buildPathInProject("regions_to_exclude", imageName + "_regions_to_exclude.txt"))
     atlas.saveExcludedRegions(exclusionsFile)

--- a/src/main/resources/scripts/detect_cells_for_multiple_projects.groovy
+++ b/src/main/resources/scripts/detect_cells_for_multiple_projects.groovy
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/*
+ * REQUIREMENTS
+ * ============
+ * You need to:
+ *  - have a BraiAn.yml file in the project folder (or its parent directory)
+ *  - have images which have been registered and imported with ABBA (https://github.com/BIOP/qupath-extension-abba/)
+ *  - have excluded the brain regions that are missing or badly aligned to the image
+ *    This can be done by:
+ *      + either drawing a larger annotation, classified as "Exclude", that contains the above mentioned regions
+ *      + or DUPLICATING (SHIFT+D) a brain region annotation and then classifying it as "Exclude"
+ *
+ * This script then reads the config file, and based on that, for each of the chosen image channels:
+ *  - computes the detection using WatershedCellDetection algorithm with an automatic threshold
+ *  - classifies the detection on each regions with the chosen classifier
+ *  - finds all detections that are double (or triple/multiple) positive
+ *  - exports to file the number of detections/double+ found in each brain region
+ *  - exports to file a list of regions that have to be excluded from further analysis
+ */
+import qupath.lib.gui.scripting.QPEx
+import qupath.lib.projects.ProjectIO
+import qupath.lib.projects.Project
+import qupath.lib.images.ImageData
+import java.awt.image.BufferedImage
+import java.nio.file.Paths
+import qupath.ext.braian.AtlasManager
+import qupath.ext.braian.OverlappingDetections
+import qupath.ext.braian.ImageChannelTools
+import qupath.ext.braian.ChannelDetections
+import qupath.ext.braian.config.ProjectsConfig
+
+// Configuration - UPDATE THESE PATHS
+PROJECTS_DIR = "/path/to/QuPath_projects/"
+PROJECT_NAMES = [
+    "project1", "project2", "project3", "project4",
+]
+ATLAS_NAME = "allen_mouse_10um_java"
+
+PROJECT_NAMES.each { projectName ->
+    def projectPath = Paths.get(PROJECTS_DIR, projectName, "project.qpproj").toFile()
+    if (!projectPath.exists()) {
+        println "Project not found: ${projectPath}"
+        return
+    }
+    
+    println "\n=== Processing project: ${projectName} ==="
+    
+    Project<BufferedImage> project = ProjectIO.loadProject(projectPath, BufferedImage.class)
+    def projectDir = project.getPath().getParent()
+    
+    try {
+        project.getImageList().each { entry ->
+            ImageData<BufferedImage> imageData = null
+            try {
+                println "  Processing image: ${entry.getImageName()}"
+                imageData = entry.readImageData()
+                QPEx.setBatchProjectAndImage(project, imageData)
+                
+                // === Begin BraiAn detection logic ===
+                var hierarchy = imageData.getHierarchy()
+                var config = ProjectsConfig.read("BraiAn.yml")
+                var annotations = config.getAnnotationsForDetections(hierarchy)
+                
+                // COMPUTE CHANNEL DETECTIONS
+                var allDetections = config.channelDetections.collect { detectionsConf ->
+                    var channel = new ImageChannelTools(detectionsConf.name, imageData)
+                    try {
+                        new ChannelDetections(channel, annotations, detectionsConf.parameters, hierarchy)
+                    } catch (IllegalArgumentException ignored) {
+                        null
+                    }
+                }.findAll { it != null }
+                
+                if (allDetections.isEmpty()) {
+                    println "  ${entry.getImageName()} : DONE! No annotations found to compute on"
+                    return
+                }
+                
+                // CLASSIFY CHANNEL DETECTIONS
+                allDetections.forEach { detections ->
+                    var detectionsConfig = config.channelDetections.find { detectionsConf -> detectionsConf.name == detections.getId() }
+                    if (detectionsConfig.classifiers == null)
+                        return
+                    var partialClassifiers = detectionsConfig.classifiers.collect{ it.toPartialClassifier(hierarchy) }
+                    detections.applyClassifiers(partialClassifiers, imageData)
+                }
+                
+                var overlaps = []
+                Optional<String> control
+                if ((control = config.getControlChannel()).isPresent() ) {
+                    String controlChannelName = control.get()
+                    var controlChannel = allDetections.find { it.getId() == controlChannelName }
+                    var otherChannels = allDetections.findAll { it.getId() != controlChannelName }
+                    overlaps = [new OverlappingDetections(controlChannel, otherChannels, true, hierarchy)]
+                }
+                
+                // EXPORT RESULTS
+                if (AtlasManager.isImported(ATLAS_NAME, hierarchy)) {
+                    var atlas = new AtlasManager(ATLAS_NAME, hierarchy)
+                    
+                    // Sanitize image name for filesystem
+                    INVALID_CHARS_WIN = ['<', '>' ,':', '"', '/', '\\', '|', '?', '*'] as Set<Character>
+                    INVALID_CHARS_NIX = ['/'] as Set<Character>
+                    def invalid_chars_regex = (INVALID_CHARS_WIN + INVALID_CHARS_NIX).collect { java.util.regex.Pattern.quote(it) }.join('|')
+                    def imageName = entry.getImageName().replaceAll(invalid_chars_regex, '')
+                    
+                    // Build paths relative to project directory
+                    var resultsDir = projectDir.resolve("results").toFile()
+                    resultsDir.mkdirs()
+                    var resultsFile = new File(resultsDir, imageName + "_regions.tsv")
+                    atlas.saveResults(allDetections + overlaps, resultsFile, imageData, entry)
+                    
+                    var exclusionsDir = projectDir.resolve("regions_to_exclude").toFile()
+                    exclusionsDir.mkdirs()
+                    def exclusionsFile = new File(exclusionsDir, imageName + "_regions_to_exclude.txt")
+                    atlas.fixExclusions()
+                    atlas.saveExcludedRegions(exclusionsFile)
+                }
+                
+                println "  ${entry.getImageName()} : DONE!"
+                // === End BraiAn detection logic ===
+                
+                // Save the changes back to the project
+                entry.saveImageData(imageData)
+                println "  Successfully processed and saved ${entry.getImageName()}"
+                
+            } catch (Exception e) {
+                println "  ERROR processing ${entry.getImageName()}: ${e.message}"
+                e.printStackTrace()
+                throw e // Halt on error
+            } finally {
+                if (imageData != null && imageData.getServer() != null) {
+                    try {
+                        imageData.getServer().close()
+                    } catch (Exception e) {
+                        println "  Warning: Failed to close image server: ${e.message}"
+                    }
+                }
+                QPEx.resetBatchProjectAndImage()
+            }
+        }
+        project.syncChanges()
+        println "=== Finished project: ${projectName} ==="
+        
+    } catch (Exception e) {
+        println "ERROR processing project ${projectName}: ${e.message}"
+        e.printStackTrace()
+        throw e // Halt on error
+    } finally {
+        project = null
+        System.gc()
+    }
+}
+
+println "\n=== All projects processed successfully! ==="


### PR DESCRIPTION
Removes reliance on QuPath's global scripting context (`QP.*` static calls) by threading `ImageData`, `PathObjectHierarchy`, and `Project` references explicitly through the API.

### Motivation

The existing API uses `QP.getCurrentImageData()` and similar static accessors throughout. This couples library code to the scripting environment and makes it impossible to use in non-interactive contexts (batch processing, testing, GUI threads). Explicit parameters make the code testable and reusable.

### Changes

- **Modified**: `BraiAn` utility — add project-aware path resolution methods
- **Modified**: `ProjectsConfig`, `ChannelClassifierConfig` — accept explicit project context instead of `QP.getProject()`
- **Modified**: `AbstractDetections`, `ChannelDetections`, `OverlappingDetections` — pass `ImageData`/`Hierarchy` as parameters
- **Modified**: `AtlasManager` — remove internal `QP.*` calls, accept explicit server/hierarchy references
- **Modified**: `ImageChannelTools` — accept `ImageData` in constructor
- **Modified**: Groovy scripts — update to pass context explicitly

### Build

`./gradlew compileJava` ✅

> **Note**: This is the largest refactor in the series. Each commit touches one layer (utils → config → detections → atlas → scripts) so the progression is reviewable commit-by-commit.

_Part of the PR #7 split — see #7 for full context._