### PR TITLE
feat: add GUI-based pipeline manager

### DIFF
--- a/src/main/java/qupath/ext/braian/gui/BraiAnDetectDialog.java
+++ b/src/main/java/qupath/ext/braian/gui/BraiAnDetectDialog.java
@@ -1,0 +1,914 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.gui;
+
+import javafx.animation.PauseTransition;
+import javafx.application.Platform;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.ListView;
+import javafx.scene.control.Label;
+import javafx.scene.control.RadioButton;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.cell.CheckBoxListCell;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Separator;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+import javafx.util.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.ext.braian.ExclusionReport;
+import qupath.ext.braian.config.ProjectsConfig;
+import qupath.ext.braian.runners.ABBAImporterRunner;
+import qupath.ext.braian.runners.AutoExcludeEmptyRegionsRunner;
+import qupath.ext.braian.runners.BraiAnAnalysisRunner;
+import qupath.ext.braian.runners.ClassifierSampleRunner;
+import qupath.ext.braian.utils.BraiAn;
+import qupath.ext.braian.utils.ProjectDiscoveryService;
+import qupath.fx.dialogs.Dialogs;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.images.ImageData;
+import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.projects.Project;
+import qupath.lib.projects.Projects;
+import org.yaml.snakeyaml.error.YAMLException;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.awt.Desktop;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Main JavaFX dialog for the BraiAn pipeline manager.
+ */
+public class BraiAnDetectDialog {
+    private static final Logger logger = LoggerFactory.getLogger(BraiAnDetectDialog.class);
+    private static final String CONFIG_FILENAME = "BraiAn.yml";
+
+    private final QuPathGUI qupath;
+    private final Stage stage;
+    private final ChangeListener<Project<BufferedImage>> projectListener = (obs, oldValue, newValue) -> Platform
+            .runLater(this::updateConfigForContext);
+    private final BooleanProperty batchMode = new SimpleBooleanProperty(false);
+    private final BooleanProperty batchReady = new SimpleBooleanProperty(false);
+    private final BooleanProperty running = new SimpleBooleanProperty(false);
+    private final TextField batchRootField = new TextField();
+    private final BooleanProperty importBatchMode = new SimpleBooleanProperty(false);
+    private final TextField importBatchRootField = new TextField();
+    private final TextField importAtlasNameField = new TextField();
+    private final PauseTransition saveDebounce = new PauseTransition(Duration.millis(500));
+    private final ExecutorService saveExecutor = Executors.newSingleThreadExecutor();
+    private final ExecutorService runExecutor = Executors.newSingleThreadExecutor();
+    private final ObservableList<String> channelNames = FXCollections.observableArrayList();
+    private final ObservableList<DiscoveredProject> discoveredProjects = FXCollections.observableArrayList();
+    private final List<String> availableImageChannels = new ArrayList<>();
+    private ProjectsConfig config;
+    private Path configPath;
+    private ExperimentPane experimentPane;
+    private Runnable onClose;
+
+    private static final class DiscoveredProject {
+        private final String name;
+        private final Path projectFile;
+        private final BooleanProperty selected = new SimpleBooleanProperty(true);
+
+        private DiscoveredProject(String name, Path projectFile, boolean selected) {
+            this.name = name;
+            this.projectFile = projectFile;
+            this.selected.set(selected);
+        }
+
+        public Path getProjectFile() {
+            return projectFile;
+        }
+
+        public BooleanProperty selectedProperty() {
+            return selected;
+        }
+
+        public boolean isSelected() {
+            return selected.get();
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    public enum InitialTab {
+        IMPORT,
+        DETECTION
+    }
+
+    /**
+     * Creates the main BraiAnDetect dialog.
+     *
+     * @param qupath     the QuPath GUI instance
+     * @param initialTab which tab should be selected initially
+     */
+    public BraiAnDetectDialog(QuPathGUI qupath, InitialTab initialTab) {
+        this.qupath = qupath;
+        this.stage = new Stage();
+        this.stage.setTitle("BraiAnDetect Pipeline Manager");
+        this.stage.initOwner(qupath.getStage());
+        this.stage.setWidth(600);
+        this.stage.setHeight(820);
+        this.batchReady.bind(batchRootField.textProperty().isNotEmpty());
+        this.stage.setOnHidden(event -> {
+            shutdownExecutors();
+            if (onClose != null) {
+                onClose.run();
+            }
+        });
+
+        initializeConfig();
+
+        qupath.projectProperty().addListener(projectListener);
+        this.stage.setScene(new Scene(buildRoot(initialTab)));
+    }
+
+    /**
+     * Registers a callback to run when the dialog closes.
+     *
+     * @param onClose callback invoked after the dialog is hidden
+     */
+    public void setOnClose(Runnable onClose) {
+        this.onClose = onClose;
+    }
+
+    /**
+     * Shows the dialog and brings it to the front.
+     */
+    public void show() {
+        this.stage.show();
+        this.stage.toFront();
+    }
+
+    private void initializeConfig() {
+        Project<BufferedImage> project = qupath.getProject();
+        if (project == null) {
+            Dialogs.showErrorMessage("BraiAnDetect", "Open a project before launching the GUI.");
+            throw new IllegalStateException("No project open");
+        }
+        loadConfig(resolveConfigPath());
+        ImageData<BufferedImage> imageData = qupath.getViewer() != null ? qupath.getViewer().getImageData() : null;
+        if (imageData != null) {
+            for (ImageChannel channel : imageData.getServerMetadata().getChannels()) {
+                availableImageChannels.add(channel.getName());
+            }
+        }
+    }
+
+    private Parent buildRoot(InitialTab initialTab) {
+        TabPane tabPane = new TabPane();
+        Tab importTab = buildImportTab();
+        Tab experimentTab = buildExperimentTab();
+
+        tabPane.getTabs().addAll(importTab, experimentTab);
+        tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
+
+        if (initialTab == InitialTab.DETECTION) {
+            tabPane.getSelectionModel().select(experimentTab);
+        } else {
+            tabPane.getSelectionModel().select(importTab);
+        }
+
+        BorderPane root = new BorderPane(tabPane);
+        root.setPadding(new Insets(8));
+        return root;
+    }
+
+    private Tab buildImportTab() {
+        VBox container = new VBox(16);
+        container.setPadding(new Insets(16));
+
+        ToggleGroup scopeGroup = new ToggleGroup();
+        RadioButton currentImageToggle = new RadioButton("Current Image");
+        RadioButton currentProjectToggle = new RadioButton("Current Project");
+        RadioButton experimentToggle = new RadioButton("Experiment");
+        currentImageToggle.setToggleGroup(scopeGroup);
+        currentProjectToggle.setToggleGroup(scopeGroup);
+        experimentToggle.setToggleGroup(scopeGroup);
+        currentProjectToggle.setSelected(true);
+
+        HBox scopeRow = new HBox(16, new Label("Scope:"), currentImageToggle, currentProjectToggle, experimentToggle);
+        scopeRow.setAlignment(Pos.CENTER_LEFT);
+
+        currentImageToggle.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (selected) {
+                importBatchMode.set(false);
+            }
+        });
+        currentProjectToggle.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (selected) {
+                importBatchMode.set(false);
+            }
+        });
+        experimentToggle.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (selected) {
+                importBatchMode.set(true);
+                refreshDiscoveredProjects(resolveImportBatchRoot());
+            }
+        });
+
+        HBox batchChooserRow = new HBox(8);
+        batchChooserRow.setAlignment(Pos.CENTER_LEFT);
+        importBatchRootField.setPromptText("Select a root folder containing QuPath projects");
+        importBatchRootField.setEditable(true);
+        importBatchRootField.textProperty().addListener((obs, oldValue, value) -> {
+            if (importBatchMode.get()) {
+                refreshDiscoveredProjects(resolveImportBatchRoot());
+            }
+        });
+        Button browseButton = new Button("Browse");
+        browseButton.setOnAction(event -> chooseBatchFolder(stage, importBatchRootField));
+        HBox.setHgrow(importBatchRootField, Priority.ALWAYS);
+        batchChooserRow.getChildren().addAll(new Label("Projects Folder:"), importBatchRootField, browseButton);
+        batchChooserRow.managedProperty().bind(importBatchMode);
+        batchChooserRow.visibleProperty().bind(importBatchMode);
+
+        VBox importAtlasPanel = new VBox(10);
+        importAtlasPanel.setPadding(new Insets(12));
+        importAtlasPanel.setStyle(
+                "-fx-border-color: -fx-box-border; -fx-border-radius: 6; -fx-background-radius: 6; -fx-background-color: -fx-control-inner-background;");
+
+        Label importTitle = new Label("Import Atlas");
+        importTitle.setStyle("-fx-font-weight: bold;");
+
+        Button importButton = new Button("Import Atlas");
+        importButton.setTooltip(new Tooltip("Imports atlas regions into the hierarchy."));
+        importButton.disableProperty().bind(running);
+        importButton.setOnAction(event -> {
+            if (currentImageToggle.isSelected()) {
+                handleImportCurrent();
+            } else if (currentProjectToggle.isSelected()) {
+                handleImportProject();
+            } else {
+                handleImportExperiment();
+            }
+        });
+
+        Label atlasNameLabel = new Label("Atlas Name (Auto-detected):");
+        importAtlasNameField.setEditable(false);
+        importAtlasNameField.setFocusTraversable(false);
+        importAtlasNameField.setPromptText("No atlas detected");
+        Button refreshAtlasButton = new Button("Refresh");
+        refreshAtlasButton.setTooltip(new Tooltip("Re-scan projects for the imported atlas root annotation."));
+        refreshAtlasButton.disableProperty().bind(running);
+        refreshAtlasButton.setOnAction(event -> refreshAtlasDetection());
+        HBox atlasRow = new HBox(8, importAtlasNameField, refreshAtlasButton);
+        atlasRow.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(importAtlasNameField, Priority.ALWAYS);
+
+        Label warningLabel = new Label(
+                "Note: Importing atlas annotations will clear all existing objects in the hierarchy.");
+        warningLabel.getStyleClass().add("warning");
+
+        importAtlasPanel.getChildren().addAll(importTitle, importButton, atlasNameLabel, atlasRow,
+                warningLabel);
+
+        VBox projectListPanel = buildProjectListPanel(importBatchMode);
+
+        VBox autoExcludePanel = buildAutoExcludePanel(currentImageToggle, currentProjectToggle, experimentToggle);
+
+        VBox classifierSamplePanel = buildClassifierTrainingPanel();
+
+        container.getChildren().addAll(scopeRow, batchChooserRow, projectListPanel, importAtlasPanel, autoExcludePanel,
+                classifierSamplePanel);
+        return new Tab("Project Preparation", container);
+    }
+
+    private VBox buildClassifierTrainingPanel() {
+        VBox panel = new VBox(10);
+        panel.setPadding(new Insets(12));
+        panel.setStyle(
+                "-fx-border-color: -fx-box-border; -fx-border-radius: 6; -fx-background-radius: 6; -fx-background-color: -fx-control-inner-background;");
+
+        Label title = new Label("Classifier Training Sample");
+        title.setStyle("-fx-font-weight: bold;");
+
+        Label desc = new Label("Create a new project with random samples from all projects in the experiment.");
+        desc.setWrapText(true);
+
+        Spinner<Integer> samplesSpinner = new Spinner<>(1, 50, 3);
+        samplesSpinner.setEditable(true);
+        samplesSpinner.setPrefWidth(80);
+        HBox samplesRow = new HBox(10, new Label("Samples per Project:"), samplesSpinner);
+        samplesRow.setAlignment(Pos.CENTER_LEFT);
+
+        TextField projectNameField = new TextField("ClassifierTrainingGrounds");
+        HBox nameRow = new HBox(10, new Label("Project Name:"), projectNameField);
+        nameRow.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(projectNameField, Priority.ALWAYS);
+
+        Button createButton = new Button("Create Training Project");
+        createButton.setTooltip(new Tooltip(
+                "Creates a new QuPath project in the experiment folder containing sampled images."));
+        createButton.disableProperty().bind(running);
+        createButton.setOnAction(e -> {
+            Path rootPath = resolveImportBatchRoot();
+            if (rootPath == null) {
+                // If not in experiment mode, prompt for root
+                chooseBatchFolder(stage, importBatchRootField); // This updates the field
+                rootPath = resolveImportBatchRoot();
+            }
+            if (rootPath == null) {
+                Dialogs.showErrorMessage("Classifier Sample", "Select an experiment root folder first.");
+                return;
+            }
+
+            final Path experimentRoot = rootPath;
+            final int samples = samplesSpinner.getValue();
+            final String name = projectNameField.getText();
+
+            if (name == null || name.isBlank()) {
+                Dialogs.showErrorMessage("Classifier Sample", "Enter a project name.");
+                return;
+            }
+
+            runAsync("Create Classifier Project", () -> {
+                try {
+                    ClassifierSampleRunner.run(qupath, experimentRoot, samples, name);
+                } catch (IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+            });
+        });
+
+        Hyperlink docLink = new Hyperlink("Read about Classifier Training (requires cell detection first)");
+        docLink.setOnAction(e -> {
+            try {
+                Desktop.getDesktop().browse(new URI(
+                        "https://silvalab.codeberg.page/BraiAn/object-classifiers/#:~:text=interface%20(CLI).-,Classifier%20training,-Dataset%20preparation"));
+            } catch (Exception ex) {
+                logger.error("Failed to open link", ex);
+            }
+        });
+
+        panel.getChildren().addAll(title, desc, samplesRow, nameRow, createButton, docLink);
+        return panel;
+    }
+
+    private VBox buildAutoExcludePanel(RadioButton currentImageToggle, RadioButton currentProjectToggle,
+            RadioButton experimentToggle) {
+        VBox panel = new VBox(10);
+        panel.setPadding(new Insets(12));
+        panel.setStyle(
+                "-fx-border-color: -fx-box-border; -fx-border-radius: 6; -fx-background-radius: 6; -fx-background-color: -fx-control-inner-background;");
+
+        Label title = new Label("Auto-Exclude Empty Regions");
+        title.setStyle("-fx-font-weight: bold;");
+
+        ComboBox<String> channelModeSelector = new ComboBox<>(
+                FXCollections.observableArrayList("Nuclei Only", "All Channels (Max)"));
+        channelModeSelector.setValue("Nuclei Only");
+        channelModeSelector.setMaxWidth(Double.MAX_VALUE);
+        channelModeSelector.setTooltip(new Tooltip(
+                "Nuclei Only: Use only the selected nuclei channel.\nAll Channels (Max): Use the brightest value across all channels."));
+        HBox modeRow = new HBox(10, new Label("Channel Mode:"), channelModeSelector);
+        modeRow.setAlignment(Pos.CENTER_LEFT);
+
+        List<String> channelOptions = new ArrayList<>();
+        if (!availableImageChannels.isEmpty()) {
+            channelOptions.addAll(availableImageChannels);
+        } else {
+            channelOptions.addAll(List.of("Red", "Green", "Blue"));
+        }
+        ComboBox<String> channelSelector = new ComboBox<>(FXCollections.observableArrayList(channelOptions));
+        channelSelector.setPromptText("Select nuclei channel");
+        channelSelector.setMaxWidth(Double.MAX_VALUE);
+        channelSelector.setTooltip(new Tooltip("Select the channel used for nuclei staining (e.g., DAPI)."));
+        if (channelOptions.size() == 1) {
+            channelSelector.setValue(channelOptions.get(0));
+        }
+        HBox nucleiRow = new HBox(10, new Label("Nuclei channel:"), channelSelector);
+        nucleiRow.setAlignment(Pos.CENTER_LEFT);
+        nucleiRow.visibleProperty().bind(channelModeSelector.valueProperty().isEqualTo("Nuclei Only"));
+        nucleiRow.managedProperty().bind(nucleiRow.visibleProperty());
+
+        TextField multiplierField = new TextField("1.0");
+        multiplierField.setPrefWidth(60);
+        multiplierField.setTooltip(new Tooltip(
+                "Controls how many regions are excluded. Lower = stricter (fewer exclusions). Higher = more exclusions."));
+        HBox thresholdRow = new HBox(10,
+                new Label("Threshold Multiplier:"),
+                multiplierField,
+                new Label("(0.1 = fewer, 1.0 = more exclusions)"));
+        thresholdRow.setAlignment(Pos.CENTER_LEFT);
+
+        Button runButton = new Button("Run Auto-Exclusion");
+        runButton.setTooltip(
+                new Tooltip("Marks low-intensity regions as excluded based on adaptive Otsu thresholding."));
+        runButton.disableProperty().bind(running);
+        runButton.setOnAction(e -> {
+            boolean useMax = "All Channels (Max)".equals(channelModeSelector.getValue());
+            String nucleiChannel = channelSelector.getValue();
+
+            if (!useMax && (nucleiChannel == null || nucleiChannel.isBlank())) {
+                Dialogs.showErrorMessage("Auto-Exclude", "Select a nuclei channel.");
+                return;
+            }
+
+            double multiplier;
+            try {
+                multiplier = Double.parseDouble(multiplierField.getText());
+            } catch (NumberFormatException ex) {
+                Dialogs.showErrorMessage("Auto-Exclude",
+                        "Invalid threshold multiplier. Please enter a number (e.g., 1.0).");
+                return;
+            }
+
+            List<String> channelsToProcess;
+            if (useMax) {
+                channelsToProcess = new ArrayList<>(availableImageChannels);
+                if (channelsToProcess.isEmpty()) {
+                    channelsToProcess.addAll(List.of("Red", "Green", "Blue"));
+                }
+            } else {
+                channelsToProcess = List.of(nucleiChannel);
+            }
+
+            final List<Path> selectedProjectsForExperiment;
+            if (experimentToggle.isSelected()) {
+                Path rootPath = resolveImportBatchRoot();
+                if (rootPath == null) {
+                    Dialogs.showErrorMessage("Auto-Exclude",
+                            "Select a projects folder before running auto-exclusion for an experiment.");
+                    return;
+                }
+                selectedProjectsForExperiment = getSelectedProjectFiles();
+                if (selectedProjectsForExperiment.isEmpty()) {
+                    Dialogs.showErrorMessage("Auto-Exclude", "Select at least one project.");
+                    return;
+                }
+            } else {
+                selectedProjectsForExperiment = List.of();
+            }
+
+            runAsync("Auto-Exclude Empty Regions", () -> {
+                List<ExclusionReport> reports;
+                if (currentImageToggle.isSelected()) {
+                    reports = AutoExcludeEmptyRegionsRunner.runCurrentImage(qupath, channelsToProcess, useMax,
+                            multiplier);
+                } else if (currentProjectToggle.isSelected()) {
+                    reports = AutoExcludeEmptyRegionsRunner.runProject(qupath, channelsToProcess, useMax, multiplier);
+                } else {
+                    reports = AutoExcludeEmptyRegionsRunner.runBatch(qupath, selectedProjectsForExperiment,
+                            channelsToProcess, useMax, multiplier);
+                }
+
+                Platform.runLater(() -> new ExclusionReviewDialog(qupath, reports).show());
+            });
+        });
+
+        panel.getChildren().addAll(title, modeRow, nucleiRow, thresholdRow, runButton);
+        return panel;
+    }
+
+    private Tab buildExperimentTab() {
+        VBox scopeSection = new VBox(12);
+        scopeSection.setPadding(new Insets(16, 16, 0, 16));
+
+        HBox scopeRow = new HBox(16);
+        scopeRow.setAlignment(Pos.CENTER_LEFT);
+        ToggleGroup scopeGroup = new ToggleGroup();
+        RadioButton currentProjectToggle = new RadioButton("Current Project");
+        RadioButton batchToggle = new RadioButton("Experiment");
+        currentProjectToggle.setToggleGroup(scopeGroup);
+        batchToggle.setToggleGroup(scopeGroup);
+        currentProjectToggle.setSelected(true);
+        scopeRow.getChildren().addAll(new Label("Scope:"), currentProjectToggle, batchToggle);
+
+        currentProjectToggle.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (selected) {
+                batchMode.set(false);
+                updateConfigForContext();
+            }
+        });
+        batchToggle.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (selected) {
+                batchMode.set(true);
+                updateConfigForContext();
+                refreshDiscoveredProjects();
+            }
+        });
+
+        HBox batchChooserRow = new HBox(8);
+        batchChooserRow.setAlignment(Pos.CENTER_LEFT);
+        batchRootField.setPromptText("Select a root folder containing QuPath projects");
+        batchRootField.setEditable(true);
+        batchRootField.textProperty().addListener((obs, oldValue, value) -> {
+            if (batchMode.get()) {
+                updateConfigForContext();
+                refreshDiscoveredProjects();
+            }
+        });
+        Button browseButton = new Button("Browse");
+        browseButton.setOnAction(event -> chooseBatchFolder(stage, batchRootField));
+        HBox.setHgrow(batchRootField, Priority.ALWAYS);
+        batchChooserRow.getChildren().addAll(new Label("Projects Folder:"), batchRootField, browseButton);
+        batchChooserRow.managedProperty().bind(batchMode);
+        batchChooserRow.visibleProperty().bind(batchMode);
+
+        VBox projectListPanel = buildProjectListPanel(batchMode);
+        scopeSection.getChildren().addAll(scopeRow, batchChooserRow, projectListPanel, new Separator());
+
+        this.experimentPane = new ExperimentPane(
+                config,
+                channelNames,
+                availableImageChannels,
+                stage,
+                batchMode,
+                batchReady,
+                running,
+                this::handlePreview,
+                this::handleRun,
+                this::handleConfigChanged,
+                this::resolveConfigRoot,
+                this::resolveProjectDirectory,
+                qupath::getProject,
+                this::resolveImageData);
+        ScrollPane scrollPane = new ScrollPane(experimentPane);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setFitToHeight(true);
+
+        BorderPane layout = new BorderPane();
+        layout.setTop(scopeSection);
+        layout.setCenter(scrollPane);
+        return new Tab("Cell Detection", layout);
+    }
+
+    private void handleImportCurrent() {
+        runAsync("ABBA Import", () -> {
+            ABBAImporterRunner.runCurrentImage(qupath);
+            Platform.runLater(() -> experimentPane.autoDetectAtlas());
+        });
+    }
+
+    private void handleImportProject() {
+        runAsync("ABBA Import", () -> {
+            ABBAImporterRunner.runProject(qupath);
+            Platform.runLater(() -> experimentPane.autoDetectAtlas());
+        });
+    }
+
+    private void handleImportExperiment() {
+        Path rootPath = resolveImportBatchRoot();
+        if (rootPath == null) {
+            chooseBatchFolder(stage, importBatchRootField);
+            rootPath = resolveImportBatchRoot();
+        }
+        if (rootPath == null) {
+            Dialogs.showErrorMessage("BraiAnDetect", "Select a projects folder before importing to an experiment.");
+            return;
+        }
+
+        Map<Path, Boolean> selectedByPath = new HashMap<>();
+        for (DiscoveredProject project : discoveredProjects) {
+            selectedByPath.put(project.getProjectFile(), project.isSelected());
+        }
+        discoveredProjects.setAll(buildDiscoveredProjects(rootPath, selectedByPath));
+        List<Path> selectedProjects = getSelectedProjectFiles();
+        if (selectedProjects.isEmpty()) {
+            Dialogs.showErrorMessage("BraiAnDetect", "Select at least one project to import.");
+            return;
+        }
+        runAsync("ABBA Import", () -> ABBAImporterRunner.runBatch(qupath, selectedProjects));
+    }
+
+    private void handlePreview() {
+        if (!flushConfigNow()) {
+            return;
+        }
+        runAsync("Preview", () -> BraiAnAnalysisRunner.runPreview(qupath));
+    }
+
+    private void handleRun() {
+        if (!flushConfigNow()) {
+            return;
+        }
+        if (batchMode.get()) {
+            Path rootPath = resolveBatchRoot();
+            if (rootPath == null) {
+                Dialogs.showErrorMessage("BraiAnDetect", "Select a projects folder before running batch detection.");
+                return;
+            }
+            List<Path> selectedProjects = getSelectedProjectFiles();
+            if (selectedProjects.isEmpty()) {
+                Dialogs.showErrorMessage("BraiAnDetect", "Select at least one project to run detection.");
+                return;
+            }
+            runAsync("Run Batch Detection", () -> BraiAnAnalysisRunner.runBatch(qupath, rootPath, selectedProjects));
+        } else {
+            runAsync("Run Detection", () -> BraiAnAnalysisRunner.runProject(qupath));
+        }
+    }
+
+    private VBox buildProjectListPanel(BooleanProperty visibility) {
+        ListView<DiscoveredProject> listView = new ListView<>(discoveredProjects);
+        listView.setCellFactory(CheckBoxListCell.forListView(DiscoveredProject::selectedProperty));
+        listView.setPrefHeight(160);
+        listView.managedProperty().bind(visibility);
+        listView.visibleProperty().bind(visibility);
+
+        Label label = new Label("Discovered projects");
+        label.managedProperty().bind(visibility);
+        label.visibleProperty().bind(visibility);
+
+        VBox panel = new VBox(8, label, listView);
+        panel.managedProperty().bind(visibility);
+        panel.visibleProperty().bind(visibility);
+        return panel;
+    }
+
+    private void refreshDiscoveredProjects() {
+        Path rootPath = resolveBatchRoot();
+        refreshDiscoveredProjects(rootPath);
+    }
+
+    private void refreshDiscoveredProjects(Path rootPath) {
+        if (rootPath == null) {
+            discoveredProjects.clear();
+            return;
+        }
+
+        Map<Path, Boolean> selectedByPath = new HashMap<>();
+        for (DiscoveredProject project : discoveredProjects) {
+            selectedByPath.put(project.getProjectFile(), project.isSelected());
+        }
+
+        runAsync("Discover Projects", () -> {
+            List<DiscoveredProject> refreshed = buildDiscoveredProjects(rootPath, selectedByPath);
+            Platform.runLater(() -> discoveredProjects.setAll(refreshed));
+        });
+    }
+
+    private List<DiscoveredProject> buildDiscoveredProjects(Path rootPath, Map<Path, Boolean> selectedByPath) {
+        if (rootPath == null) {
+            return List.of();
+        }
+        List<Path> projectFiles = ProjectDiscoveryService.discoverProjectFiles(rootPath);
+        List<DiscoveredProject> refreshed = new ArrayList<>();
+        for (Path projectFile : projectFiles) {
+            String name = projectFile.getParent().getFileName().toString();
+            boolean selected = selectedByPath.getOrDefault(projectFile, true);
+            refreshed.add(new DiscoveredProject(name, projectFile, selected));
+        }
+        return refreshed;
+    }
+
+    private List<Path> getSelectedProjectFiles() {
+        return discoveredProjects.stream()
+                .filter(DiscoveredProject::isSelected)
+                .map(DiscoveredProject::getProjectFile)
+                .toList();
+    }
+
+    private boolean flushConfigNow() {
+        saveDebounce.stop();
+        if (configPath == null) {
+            Dialogs.showErrorMessage("BraiAnDetect",
+                    "No configuration path is available. Select a valid project or batch folder.");
+            return false;
+        }
+        try {
+            writeConfigNow(ProjectsConfig.toYaml(config));
+            return true;
+        } catch (IOException e) {
+            Dialogs.showErrorMessage("BraiAnDetect", "Failed to save BraiAn.yml: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private void scheduleConfigSave() {
+        saveDebounce.stop();
+        saveDebounce.setOnFinished(event -> saveConfigAsync(ProjectsConfig.toYaml(config)));
+        saveDebounce.playFromStart();
+    }
+
+    private void saveConfigAsync(String yaml) {
+        if (configPath == null) {
+            logger.warn("Config path is not available; skipping save.");
+            return;
+        }
+        if (saveExecutor.isShutdown()) {
+            return;
+        }
+        saveExecutor.execute(() -> {
+            try {
+                writeConfigNow(yaml);
+            } catch (IOException e) {
+                logger.error("Failed to save config", e);
+            }
+        });
+    }
+
+    private void writeConfigNow(String yaml) throws IOException {
+        if (configPath.getParent() != null) {
+            Files.createDirectories(configPath.getParent());
+        }
+        Files.writeString(configPath, yaml, StandardCharsets.UTF_8);
+    }
+
+    private void loadConfig(Path path) {
+        if (path == null) {
+            return;
+        }
+        ProjectsConfig loadedConfig;
+        try {
+            if (Files.exists(path)) {
+                loadedConfig = ProjectsConfig.read(path);
+            } else {
+                loadedConfig = new ProjectsConfig();
+            }
+        } catch (IOException | YAMLException e) {
+            Dialogs.showErrorMessage("BraiAnDetect", "Unable to load BraiAn.yml: " + e.getMessage());
+            loadedConfig = new ProjectsConfig();
+        }
+        this.config = loadedConfig;
+        this.configPath = path;
+        if (experimentPane != null) {
+            experimentPane.setConfig(loadedConfig);
+        }
+        updateAtlasNameFields();
+        if (!Files.exists(path)) {
+            saveConfigAsync(ProjectsConfig.toYaml(loadedConfig));
+        }
+    }
+
+    private void updateConfigForContext() {
+        Path resolved = resolveConfigPath();
+        if (resolved == null) {
+            return;
+        }
+        if (configPath != null && configPath.equals(resolved)) {
+            return;
+        }
+        loadConfig(resolved);
+    }
+
+    private void handleConfigChanged() {
+        scheduleConfigSave();
+        updateAtlasNameFields();
+    }
+
+    private void refreshAtlasDetection() {
+        if (experimentPane != null) {
+            experimentPane.refreshAtlasDetection();
+        }
+    }
+
+    private void updateAtlasNameFields() {
+        if (config == null) {
+            importAtlasNameField.setText("");
+            return;
+        }
+        String atlasName = config.getAtlasName();
+        importAtlasNameField.setText(atlasName == null ? "" : atlasName);
+    }
+
+    private Path resolveConfigPath() {
+        if (batchMode.get()) {
+            String root = batchRootField.getText();
+            if (root == null || root.isBlank()) {
+                return null;
+            }
+            return Path.of(root).resolve(CONFIG_FILENAME);
+        }
+        Optional<Path> configPathOpt = BraiAn.resolvePathIfPresent(qupath.getProject(), CONFIG_FILENAME);
+        if (configPathOpt.isPresent()) {
+            return configPathOpt.get();
+        }
+        Path projectDir = resolveProjectDirectory();
+        if (projectDir == null) {
+            return null;
+        }
+        return projectDir.resolve(CONFIG_FILENAME);
+    }
+
+    private void chooseBatchFolder(Window owner, TextField targetField) {
+        DirectoryChooser chooser = new DirectoryChooser();
+        chooser.setTitle("Select QuPath Projects Folder");
+        Path projectDir = resolveProjectDirectory();
+        if (projectDir != null && Files.exists(projectDir)) {
+            chooser.setInitialDirectory(projectDir.toFile());
+        }
+        var selection = chooser.showDialog(owner);
+        if (selection != null) {
+            targetField.setText(selection.getAbsolutePath());
+        }
+    }
+
+    private Path resolveConfigRoot() {
+        if (configPath != null) {
+            return configPath.getParent();
+        }
+        return resolveProjectDirectory();
+    }
+
+    private Path resolveBatchRoot() {
+        String root = batchRootField.getText();
+        if (root == null || root.isBlank()) {
+            return null;
+        }
+        Path path = Path.of(root);
+        if (!Files.isDirectory(path)) {
+            return null;
+        }
+        return path;
+    }
+
+    private Path resolveImportBatchRoot() {
+        String root = importBatchRootField.getText();
+        if (root == null || root.isBlank()) {
+            return null;
+        }
+        Path path = Path.of(root);
+        if (!Files.isDirectory(path)) {
+            return null;
+        }
+        return path;
+    }
+
+    private void runAsync(String title, Runnable task) {
+        if (running.get() || runExecutor.isShutdown()) {
+            return;
+        }
+        running.set(true);
+        runExecutor.execute(() -> {
+            try {
+                task.run();
+            } catch (Exception e) {
+                logger.error("{} failed", title, e);
+                showError(title, e);
+            } finally {
+                Platform.runLater(() -> running.set(false));
+            }
+        });
+    }
+
+    private void showError(String title, Exception e) {
+        String message = e.getMessage();
+        if (message == null || message.isBlank()) {
+            message = "Unexpected error. See log for details.";
+        }
+        String finalMessage = message;
+        Platform.runLater(() -> Dialogs.showErrorMessage(title, finalMessage));
+    }
+
+    private void shutdownExecutors() {
+        saveDebounce.stop();
+        qupath.projectProperty().removeListener(projectListener);
+        saveExecutor.shutdown();
+        runExecutor.shutdown();
+    }
+
+    private Path resolveProjectDirectory() {
+        Project<BufferedImage> project = qupath.getProject();
+        if (project == null) {
+            return null;
+        }
+        return Projects.getBaseDirectory(project).toPath();
+    }
+
+    private ImageData<BufferedImage> resolveImageData() {
+        return qupath.getViewer() != null ? qupath.getViewer().getImageData() : null;
+    }
+}

--- a/src/main/java/qupath/ext/braian/gui/ChannelCard.java
+++ b/src/main/java/qupath/ext/braian/gui/ChannelCard.java
@@ -1,0 +1,937 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.gui;
+
+import javafx.beans.binding.Bindings;
+import javafx.collections.FXCollections;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.RadioButton;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.Separator;
+import javafx.scene.control.TitledPane;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.stage.FileChooser;
+import javafx.stage.Stage;
+import qupath.ext.braian.config.AutoThresholdParmameters;
+import qupath.ext.braian.config.ChannelClassifierConfig;
+import qupath.ext.braian.config.ChannelDetectionsConfig;
+import qupath.ext.braian.config.PixelClassifierConfig;
+import qupath.ext.braian.config.WatershedCellDetectionConfig;
+import qupath.ext.braian.ImageChannelTools;
+import qupath.fx.dialogs.Dialogs;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.images.ImageData;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+/**
+ * UI component representing a single channel configuration.
+ * <p>
+ * This card binds controls to a {@link ChannelDetectionsConfig} and emits
+ * callbacks when the
+ * configuration changes.
+ */
+public class ChannelCard extends VBox {
+    private final ChannelDetectionsConfig config;
+    private final WatershedCellDetectionConfig params;
+    private final Stage owner;
+    private final Supplier<Path> configRootSupplier;
+    private final Supplier<Path> projectDirSupplier;
+    private final Runnable onConfigChanged;
+    private final Runnable onChannelNameChanged;
+    private final BooleanSupplier isUpdatingSupplier;
+    private final Supplier<ImageData<?>> imageDataSupplier;
+    private final VBox classifierList = new VBox(6);
+    private final VBox pixelClassifierList = new VBox(6);
+    private final List<ChannelClassifierConfig> classifiers;
+    private final List<PixelClassifierConfig> pixelClassifiers;
+    private Runnable onRemove = () -> {
+    };
+
+    private static final String HELP_URL_THRESHOLD = "https://silvalab.codeberg.page/BraiAn/image-analysis/#:~:text=Automatic%20threshold";
+
+    private static final String TOOLTIP_PIXEL_SIZE = "Choose pixel size at which detection will be performed - higher values are likely to be faster, but may be less accurate; set <= 0 to use the full image resolution";
+    private static final String TOOLTIP_BACKGROUND_RADIUS = "Radius for background estimation, should be > the largest nucleus radius, or <= 0 to turn off background subtraction";
+    private static final String TOOLTIP_BACKGROUND_RECONSTRUCTION = "Use opening-by-reconstruction for background estimation (default is 'true'). Opening by reconstruction tends to give a 'better' background estimate, because it incorporates more information across the image tile used for cell detection. However, in some cases (e.g. images with prominent folds, background staining, or other artefacts) this can cause problems, with the background estimate varying substantially between tiles. Opening by reconstruction was always used in QuPath before v0.4.0, but now it is optional.";
+    private static final String TOOLTIP_MEDIAN_RADIUS = "Radius of median filter used to reduce image texture (optional)";
+    private static final String TOOLTIP_SIGMA = "Sigma value for Gaussian filter used to reduce noise; increasing the value stops nuclei being fragmented, but may reduce the accuracy of boundaries";
+    private static final String TOOLTIP_MIN_AREA = "Detected nuclei with an area < minimum area will be discarded";
+    private static final String TOOLTIP_MAX_AREA = "Detected nuclei with an area > maximum area will be discarded";
+    private static final String TOOLTIP_THRESHOLD = "Intensity threshold - detected nuclei must have a mean intensity >= threshold";
+    private static final String TOOLTIP_HIST_RESOLUTION = "Resolution level at which the histogram is computed";
+    private static final String TOOLTIP_HIST_SMOOTH = "Size of the window used by the moving average to smooth the histogram";
+    private static final String TOOLTIP_HIST_PEAK = "Amount of prominence from the surrounding values in the histogram for a local maximum to be considered a 'peak'";
+    private static final String TOOLTIP_HIST_NPEAK = "n-th peak to use as threshold (starts from 1)";
+    private static final String TOOLTIP_WATERSHED = "Split merged detected nuclei based on shape ('roundness')";
+    private static final String TOOLTIP_CELL_EXPANSION = "Amount by which to expand detected nuclei to approximate the full cell area";
+    private static final String TOOLTIP_INCLUDE_NUCLEI = "If cell expansion is used, optionally include/exclude the nuclei within the detected cells";
+    private static final String TOOLTIP_SMOOTH_BOUNDARIES = "Smooth the detected nucleus/cell boundaries";
+    private static final String TOOLTIP_MAKE_MEASUREMENTS = "Add default shape & intensity measurements during detection";
+    private static final String TOOLTIP_CLASSIFIER_REGIONS = "List of the annotation names for which the classifier is applied";
+    private static final String TOOLTIP_PIXEL_CLASSIFIER_REGIONS = "List of atlas regions for which the pixel classifier is applied";
+
+    private static final String BADGE_GLOBAL_TEXT = "🌍 Global";
+    private static final String BADGE_PARTIAL_TEXT = "🎯 Partial";
+    private static final String BADGE_GLOBAL_STYLE = "-fx-background-color: #E6F4EA; -fx-text-fill: #137333; -fx-background-radius: 8; -fx-padding: 2 8; -fx-font-size: 10px; -fx-font-weight: bold;";
+    private static final String BADGE_PARTIAL_STYLE = "-fx-background-color: #E8F0FE; -fx-text-fill: #1A73E8; -fx-background-radius: 8; -fx-padding: 2 8; -fx-font-size: 10px; -fx-font-weight: bold;";
+
+    /**
+     * Creates a channel card.
+     *
+     * @param config               the per-channel configuration to edit
+     * @param availableChannels    list of channel names that can be selected
+     * @param owner                owning stage used for dialogs
+     * @param configRootSupplier   supplier for the directory containing
+     *                             configuration resources
+     * @param projectDirSupplier   supplier for the current project directory
+     * @param onConfigChanged      callback invoked when configuration is changed
+     * @param onChannelNameChanged callback invoked when the channel name is changed
+     * @param isUpdatingSupplier   supplier indicating whether UI is being updated
+     *                             programmatically
+     * @param imageDataSupplier    supplier for the current ImageData
+     */
+    public ChannelCard(ChannelDetectionsConfig config,
+            List<String> availableChannels,
+            Stage owner,
+            Supplier<Path> configRootSupplier,
+            Supplier<Path> projectDirSupplier,
+            Runnable onConfigChanged,
+            Runnable onChannelNameChanged,
+            BooleanSupplier isUpdatingSupplier,
+            Supplier<ImageData<?>> imageDataSupplier) {
+        this.config = config;
+        this.params = config.getParameters();
+        this.owner = owner;
+        this.configRootSupplier = configRootSupplier;
+        this.projectDirSupplier = projectDirSupplier;
+        this.onConfigChanged = onConfigChanged;
+        this.onChannelNameChanged = onChannelNameChanged;
+        this.isUpdatingSupplier = isUpdatingSupplier;
+        this.imageDataSupplier = imageDataSupplier;
+        this.classifiers = new ArrayList<>(Optional.ofNullable(config.getClassifiers()).orElse(List.of()));
+        this.pixelClassifiers = new ArrayList<>(Optional.ofNullable(config.getPixelClassifiers()).orElse(List.of()));
+
+        setSpacing(12);
+        setPadding(new Insets(12));
+
+        ComboBox<String> channelName = new ComboBox<>(FXCollections.observableArrayList(availableChannels));
+        channelName.setEditable(true);
+        channelName.setPromptText("Channel name");
+        channelName.setValue(config.getName());
+        channelName.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            String name = value != null ? value.trim() : null;
+            if (name != null && name.isEmpty()) {
+                name = null;
+            }
+            config.setName(name);
+            if (name != null) {
+                config.setClassifiers(new ArrayList<>(classifiers));
+            }
+            notifyChannelNameChanged();
+            notifyConfigChanged();
+        });
+
+        Spinner<Integer> channelIdSpinner = createIntegerSpinner(1, 16, config.getInputChannelID(), 1);
+        channelIdSpinner.setPrefWidth(60);
+        channelIdSpinner.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            config.setInputChannelID(value);
+            notifyConfigChanged();
+        });
+
+        Button removeButton = new Button("Remove");
+        removeButton.setOnAction(event -> onRemove.run());
+
+        HBox header = new HBox(8, new Label("Source Ch"), channelIdSpinner, new Label("-> Name"), channelName,
+                removeButton);
+        header.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(channelName, Priority.ALWAYS);
+
+        CheckBox enableCellDetection = new CheckBox("Enable Cell Detection");
+        enableCellDetection.setSelected(config.isEnableCellDetection());
+        enableCellDetection.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            config.setEnableCellDetection(selected);
+            notifyConfigChanged();
+        });
+
+        CheckBox enablePixelClassification = new CheckBox("Enable Pixel Classification");
+        enablePixelClassification.setSelected(config.isEnablePixelClassification());
+        enablePixelClassification.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            config.setEnablePixelClassification(selected);
+            notifyConfigChanged();
+        });
+
+        ToggleGroup thresholdGroup = new ToggleGroup();
+        RadioButton autoThreshold = new RadioButton("Auto");
+        RadioButton manualThreshold = new RadioButton("Manual");
+        autoThreshold.setToggleGroup(thresholdGroup);
+        manualThreshold.setToggleGroup(thresholdGroup);
+
+        Spinner<Double> thresholdSpinner = createDoubleSpinner(0, 65535, 1, params.getThreshold());
+        thresholdSpinner.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setThreshold(value);
+            notifyConfigChanged();
+        });
+        addTooltip(thresholdSpinner, TOOLTIP_THRESHOLD);
+
+        Label manualDefault = new Label("[default: 100]");
+        manualDefault.setStyle("-fx-text-fill: #888; -fx-font-size: 10px;");
+        HBox thresholdControlBox = new HBox(8, thresholdSpinner, manualDefault);
+        thresholdControlBox.setAlignment(Pos.CENTER_LEFT);
+        VBox manualBox = new VBox(6, new Label("Threshold"), thresholdControlBox);
+
+        VBox autoBox = buildAutoThresholdBox();
+
+        boolean autoEnabled = params.getHistogramThreshold() != null;
+        autoThreshold.setSelected(autoEnabled);
+        manualThreshold.setSelected(!autoEnabled);
+
+        autoBox.managedProperty().bind(autoThreshold.selectedProperty());
+        autoBox.visibleProperty().bind(autoThreshold.selectedProperty());
+        manualBox.managedProperty().bind(manualThreshold.selectedProperty());
+        manualBox.visibleProperty().bind(manualThreshold.selectedProperty());
+
+        autoThreshold.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            if (selected) {
+                ensureAutoThreshold();
+            } else {
+                params.setHistogramThreshold(null);
+            }
+            notifyConfigChanged();
+        });
+
+        Hyperlink thresholdHelp = buildHelpLink(HELP_URL_THRESHOLD);
+        HBox thresholdMode = new HBox(12, new Label("Threshold"), autoThreshold, manualThreshold, thresholdHelp);
+        thresholdMode.setAlignment(Pos.CENTER_LEFT);
+
+        GridPane standardGrid = new GridPane();
+        standardGrid.setHgap(12);
+        standardGrid.setVgap(8);
+        standardGrid.add(thresholdMode, 0, 0, 2, 1);
+        standardGrid.add(manualBox, 0, 1, 2, 1);
+        standardGrid.add(autoBox, 0, 2, 2, 1);
+
+        Spinner<Double> pixelSize = createDoubleSpinner(0.1, 10.0, 0.1, params.getRequestedPixelSizeMicrons());
+        pixelSize.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setRequestedPixelSizeMicrons(value);
+            notifyConfigChanged();
+        });
+        addTooltip(pixelSize, TOOLTIP_PIXEL_SIZE);
+        addGridRowWithDefault(standardGrid, 0, 3, "Pixel size (µm)", "0.5", pixelSize);
+
+        Spinner<Double> minArea = createDoubleSpinner(0.0, 5000.0, 1.0, params.getMinAreaMicrons());
+        minArea.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setMinAreaMicrons(value);
+            notifyConfigChanged();
+        });
+        addTooltip(minArea, TOOLTIP_MIN_AREA);
+        Spinner<Double> maxArea = createDoubleSpinner(0.0, 10000.0, 1.0, params.getMaxAreaMicrons());
+        maxArea.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setMaxAreaMicrons(value);
+            notifyConfigChanged();
+        });
+        addTooltip(maxArea, TOOLTIP_MAX_AREA);
+        addGridRowWithDefault(standardGrid, 0, 4, "Min area (µm²)", "10", minArea);
+        addGridRowWithDefault(standardGrid, 0, 5, "Max area (µm²)", "400", maxArea);
+
+        VBox standardSection = new VBox(8, new Label("Standard parameters"), standardGrid);
+
+        TitledPane advancedPane = new TitledPane("Advanced parameters", buildAdvancedSection());
+        advancedPane.setExpanded(false);
+
+        TitledPane classifiersPane = new TitledPane("Classifiers", buildClassifierSection(channelName));
+        classifiersPane.setExpanded(false);
+
+        VBox cellDetectionSection = new VBox(10, standardSection, advancedPane, classifiersPane);
+        cellDetectionSection.managedProperty().bind(enableCellDetection.selectedProperty());
+        cellDetectionSection.visibleProperty().bind(enableCellDetection.selectedProperty());
+
+        TitledPane pixelClassifierPane = new TitledPane("Pixel Classifiers", buildPixelClassifierSection(channelName));
+        pixelClassifierPane.setExpanded(false);
+        pixelClassifierPane.managedProperty().bind(enablePixelClassification.selectedProperty());
+        pixelClassifierPane.visibleProperty().bind(enablePixelClassification.selectedProperty());
+
+        HBox modeCheckboxes = new HBox(24, enableCellDetection, enablePixelClassification);
+        modeCheckboxes.setAlignment(Pos.CENTER_LEFT);
+
+        getChildren().addAll(header, modeCheckboxes, cellDetectionSection, pixelClassifierPane);
+    }
+
+    /**
+     * Sets the callback invoked when the user clicks the remove button.
+     *
+     * @param onRemove callback invoked when removing the channel; if null a no-op
+     *                 is used
+     */
+    public void setOnRemove(Runnable onRemove) {
+        this.onRemove = Objects.requireNonNullElse(onRemove, () -> {
+        });
+    }
+
+    private void addGridRow(GridPane grid, int col, int row, String label, Node control) {
+        Label lbl = new Label(label);
+        grid.add(lbl, col, row);
+        grid.add(control, col + 1, row);
+        GridPane.setHgrow(control, Priority.ALWAYS);
+    }
+
+    private void addGridRowWithDefault(GridPane grid, int col, int row, String label, String defaultVal, Node control) {
+        Label lbl = new Label(label);
+        Label defLabel = new Label("[default: " + defaultVal + "]");
+        defLabel.setStyle("-fx-text-fill: #888; -fx-font-size: 10px;");
+        HBox controlBox = new HBox(8, control, defLabel);
+        controlBox.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(control, Priority.ALWAYS);
+        grid.add(lbl, col, row);
+        grid.add(controlBox, col + 1, row);
+        GridPane.setHgrow(controlBox, Priority.ALWAYS);
+    }
+
+    private void addTooltip(Node node, String text) {
+        if (text == null || text.isBlank()) {
+            return;
+        }
+        Tooltip tooltip = new Tooltip(text);
+        tooltip.setWrapText(true);
+        tooltip.setMaxWidth(360);
+        Tooltip.install(node, tooltip);
+    }
+
+    private Hyperlink buildHelpLink(String url) {
+        Hyperlink link = new Hyperlink("(?)");
+        link.setOnAction(event -> QuPathGUI.openInBrowser(url));
+        link.setFocusTraversable(false);
+        link.setTooltip(new Tooltip("Open documentation"));
+        return link;
+    }
+
+    private Label buildSectionHeader(String text) {
+        Label label = new Label(text);
+        label.setStyle("-fx-font-weight: bold;");
+        return label;
+    }
+
+    private void updateClassifierBadge(Label badge, List<String> annotations) {
+        boolean isGlobal = annotations == null || annotations.isEmpty();
+        if (isGlobal) {
+            badge.setText(BADGE_GLOBAL_TEXT);
+            badge.setStyle(BADGE_GLOBAL_STYLE);
+        } else {
+            badge.setText(BADGE_PARTIAL_TEXT);
+            badge.setStyle(BADGE_PARTIAL_STYLE);
+        }
+    }
+
+    private Spinner<Double> createDoubleSpinner(double min, double max, double step, double value) {
+        Spinner<Double> spinner = new Spinner<>();
+        spinner.setValueFactory(new SpinnerValueFactory.DoubleSpinnerValueFactory(min, max, value, step));
+        spinner.setEditable(true);
+        return spinner;
+    }
+
+    private Spinner<Integer> createIntegerSpinner(int min, int max, int value, int step) {
+        Spinner<Integer> spinner = new Spinner<>();
+        spinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(min, max, value, step));
+        spinner.setEditable(true);
+        return spinner;
+    }
+
+    private AutoThresholdParmameters ensureAutoThreshold() {
+        AutoThresholdParmameters paramsAuto = params.getHistogramThreshold();
+        if (paramsAuto == null) {
+            paramsAuto = new AutoThresholdParmameters();
+            params.setHistogramThreshold(paramsAuto);
+        }
+        return paramsAuto;
+    }
+
+    private VBox buildAutoThresholdBox() {
+        AutoThresholdParmameters autoParams = params.getHistogramThreshold();
+        if (autoParams == null) {
+            autoParams = new AutoThresholdParmameters();
+        }
+
+        Spinner<Integer> resolutionLevel = createIntegerSpinner(0, 10, autoParams.getResolutionLevel(), 1);
+        resolutionLevel.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            ensureAutoThreshold().setResolutionLevel(value);
+            notifyConfigChanged();
+        });
+        addTooltip(resolutionLevel, TOOLTIP_HIST_RESOLUTION);
+
+        Spinner<Integer> smoothWindowSize = createIntegerSpinner(1, 100, autoParams.getSmoothWindowSize(), 1);
+        smoothWindowSize.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            ensureAutoThreshold().setSmoothWindowSize(value);
+            notifyConfigChanged();
+        });
+        addTooltip(smoothWindowSize, TOOLTIP_HIST_SMOOTH);
+
+        Spinner<Double> peakProminence = createDoubleSpinner(1, 10000, 10, autoParams.getPeakProminence());
+        peakProminence.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            ensureAutoThreshold().setPeakProminence(value);
+            notifyConfigChanged();
+        });
+        addTooltip(peakProminence, TOOLTIP_HIST_PEAK);
+
+        int nPeakValue = Math.max(1, autoParams.getnPeak() + 1);
+        Spinner<Integer> nPeak = createIntegerSpinner(1, 10, nPeakValue, 1);
+        nPeak.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            ensureAutoThreshold().setnPeak(value);
+            notifyConfigChanged();
+        });
+        addTooltip(nPeak, TOOLTIP_HIST_NPEAK);
+
+        GridPane grid = new GridPane();
+        grid.setHgap(12);
+        grid.setVgap(8);
+        addGridRowWithDefault(grid, 0, 0, "Resolution level", "4", resolutionLevel);
+        addGridRowWithDefault(grid, 0, 1, "Smooth window", "15", smoothWindowSize);
+        addGridRowWithDefault(grid, 0, 2, "Peak prominence", "100", peakProminence);
+        addGridRowWithDefault(grid, 0, 3, "Peak index", "1", nPeak);
+
+        Label thresholdResultLabel = new Label();
+        thresholdResultLabel.setStyle("-fx-font-weight: bold; -fx-text-fill: #1A73E8;");
+
+        Button findThresholdButton = new Button("Find Threshold");
+        findThresholdButton.setTooltip(new Tooltip(
+                "Calculate the automatic threshold for the current image using the parameters above."));
+        findThresholdButton.setOnAction(event -> {
+            String channelName = config.getName();
+            if (channelName == null || channelName.isBlank()) {
+                Dialogs.showErrorMessage("Find Threshold", "Please select a channel name first.");
+                return;
+            }
+            ImageData<?> imageData = imageDataSupplier.get();
+            if (imageData == null) {
+                Dialogs.showErrorMessage("Find Threshold", "No image is currently open.");
+                return;
+            }
+            AutoThresholdParmameters currentParams = ensureAutoThreshold();
+            try {
+                @SuppressWarnings("unchecked")
+                ImageData<java.awt.image.BufferedImage> typedImageData = (ImageData<java.awt.image.BufferedImage>) imageData;
+                ImageChannelTools channel = new ImageChannelTools(channelName, typedImageData);
+                int threshold = WatershedCellDetectionConfig.findThreshold(channel, currentParams);
+                thresholdResultLabel.setText("Threshold: " + threshold);
+            } catch (Exception e) {
+                Dialogs.showErrorMessage("Find Threshold",
+                        "Could not compute threshold: " + e.getMessage());
+                thresholdResultLabel.setText("");
+            }
+        });
+
+        HBox thresholdRow = new HBox(10, findThresholdButton, thresholdResultLabel);
+        thresholdRow.setAlignment(Pos.CENTER_LEFT);
+
+        return new VBox(8, new Label("Auto-threshold parameters"), grid, thresholdRow);
+    }
+
+    private VBox buildAdvancedSection() {
+        CheckBox backgroundReconstruction = new CheckBox("Background by reconstruction");
+        backgroundReconstruction.setSelected(params.isBackgroundByReconstruction());
+        backgroundReconstruction.selectedProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setBackgroundByReconstruction(value);
+            notifyConfigChanged();
+        });
+        addTooltip(backgroundReconstruction, TOOLTIP_BACKGROUND_RECONSTRUCTION);
+
+        Spinner<Double> backgroundRadius = createDoubleSpinner(0.0, 100.0, 1.0, params.getBackgroundRadiusMicrons());
+        backgroundRadius.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setBackgroundRadiusMicrons(value);
+            notifyConfigChanged();
+        });
+        addTooltip(backgroundRadius, TOOLTIP_BACKGROUND_RADIUS);
+
+        Spinner<Double> sigma = createDoubleSpinner(0.0, 5.0, 0.5, params.getSigmaMicrons());
+        sigma.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setSigmaMicrons(value);
+            notifyConfigChanged();
+        });
+        addTooltip(sigma, TOOLTIP_SIGMA);
+
+        Spinner<Double> medianRadius = createDoubleSpinner(0.0, 20.0, 0.5, params.getMedianRadiusMicrons());
+        medianRadius.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setMedianRadiusMicrons(value);
+            notifyConfigChanged();
+        });
+        addTooltip(medianRadius, TOOLTIP_MEDIAN_RADIUS);
+
+        CheckBox watershed = new CheckBox("Watershed split");
+        watershed.setSelected(params.isWatershedPostProcess());
+        watershed.selectedProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setWatershedPostProcess(value);
+            notifyConfigChanged();
+        });
+        addTooltip(watershed, TOOLTIP_WATERSHED);
+
+        Spinner<Double> cellExpansion = createDoubleSpinner(0.0, 50.0, 1.0, params.getCellExpansionMicrons());
+        cellExpansion.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setCellExpansionMicrons(value);
+            notifyConfigChanged();
+        });
+        addTooltip(cellExpansion, TOOLTIP_CELL_EXPANSION);
+
+        CheckBox includeNuclei = new CheckBox("Include nuclei");
+        includeNuclei.setSelected(params.isIncludeNuclei());
+        includeNuclei.selectedProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setIncludeNuclei(value);
+            notifyConfigChanged();
+        });
+        addTooltip(includeNuclei, TOOLTIP_INCLUDE_NUCLEI);
+
+        CheckBox smoothBoundaries = new CheckBox("Smooth boundaries");
+        smoothBoundaries.setSelected(params.isSmoothBoundaries());
+        smoothBoundaries.selectedProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setSmoothBoundaries(value);
+            notifyConfigChanged();
+        });
+        addTooltip(smoothBoundaries, TOOLTIP_SMOOTH_BOUNDARIES);
+
+        CheckBox makeMeasurements = new CheckBox("Make measurements");
+        makeMeasurements.setSelected(params.isMakeMeasurements());
+        makeMeasurements.selectedProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            params.setMakeMeasurements(value);
+            notifyConfigChanged();
+        });
+        addTooltip(makeMeasurements, TOOLTIP_MAKE_MEASUREMENTS);
+
+        GridPane preProcessingGrid = new GridPane();
+        preProcessingGrid.setHgap(12);
+        preProcessingGrid.setVgap(8);
+        addGridRowWithDefault(preProcessingGrid, 0, 0, "Median radius (µm)", "0", medianRadius);
+        addGridRowWithDefault(preProcessingGrid, 0, 1, "Sigma (µm)", "1.5", sigma);
+        addGridRowWithDefault(preProcessingGrid, 0, 2, "Background radius (µm)", "8", backgroundRadius);
+
+        VBox detectionLogicBox = new VBox(6, backgroundReconstruction, watershed);
+
+        GridPane geometryGrid = new GridPane();
+        geometryGrid.setHgap(12);
+        geometryGrid.setVgap(8);
+        addGridRowWithDefault(geometryGrid, 0, 0, "Cell expansion (µm)", "5", cellExpansion);
+
+        VBox box = new VBox(10,
+                buildSectionHeader("Pre-processing"), new Separator(), preProcessingGrid,
+                buildSectionHeader("Detection Logic"), new Separator(), detectionLogicBox,
+                buildSectionHeader("Cell Geometry"), new Separator(), geometryGrid, includeNuclei, smoothBoundaries,
+                buildSectionHeader("Output"), new Separator(), makeMeasurements);
+        return box;
+    }
+
+    private VBox buildClassifierSection(ComboBox<String> channelName) {
+        classifierList.getChildren().clear();
+        for (ChannelClassifierConfig classifier : classifiers) {
+            classifierList.getChildren().add(buildClassifierRow(classifier));
+        }
+
+        Button addClassifier = new Button("+ Add Classifier");
+        addClassifier.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+            String name = channelName.getValue();
+            return name == null || name.isBlank();
+        }, channelName.valueProperty()));
+        addClassifier.setOnAction(event -> addClassifierFromChooser());
+
+        VBox section = new VBox(8, classifierList, addClassifier);
+        return section;
+    }
+
+    private VBox buildPixelClassifierSection(ComboBox<String> channelName) {
+        pixelClassifierList.getChildren().clear();
+        for (PixelClassifierConfig classifier : pixelClassifiers) {
+            pixelClassifierList.getChildren().add(buildPixelClassifierRow(classifier));
+        }
+
+        Button addClassifier = new Button("+ Add Pixel Classifier");
+        addClassifier.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+            String name = channelName.getValue();
+            return name == null || name.isBlank();
+        }, channelName.valueProperty()));
+        addClassifier.setOnAction(event -> addPixelClassifierCard());
+
+        VBox section = new VBox(8, pixelClassifierList, addClassifier);
+        return section;
+    }
+
+    private Node buildClassifierRow(ChannelClassifierConfig classifier) {
+        String baseName = classifier.getName();
+        String fileName = baseName == null || baseName.isBlank() ? "(unnamed).json" : baseName + ".json";
+        Label nameLabel = new Label(fileName);
+        nameLabel.setStyle("-fx-font-weight: bold;");
+        nameLabel.setMinWidth(160);
+        nameLabel.setMaxWidth(Double.MAX_VALUE);
+
+        Label badge = new Label();
+        updateClassifierBadge(badge, classifier.getAnnotationsToClassify());
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        Button remove = new Button("Remove");
+        HBox header = new HBox(8, nameLabel, badge, spacer, remove);
+        header.setAlignment(Pos.CENTER_LEFT);
+
+        TextField annotations = new TextField(formatAnnotations(classifier.getAnnotationsToClassify()));
+        annotations.setPromptText("Restrict to regions (optional)");
+        addTooltip(annotations, TOOLTIP_CLASSIFIER_REGIONS);
+        annotations.textProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            List<String> parsed = parseAnnotations(value);
+            classifier.setAnnotationsToClassify(parsed.isEmpty() ? null : parsed);
+            updateClassifierBadge(badge, classifier.getAnnotationsToClassify());
+            config.setClassifiers(new ArrayList<>(classifiers));
+            notifyConfigChanged();
+        });
+
+        VBox card = new VBox(8, header, annotations);
+        card.setPadding(new Insets(10));
+        card.setStyle("-fx-background-color: -fx-control-inner-background;"
+                + "-fx-background-radius: 6;"
+                + "-fx-border-color: -fx-box-border;"
+                + "-fx-border-radius: 6;");
+
+        remove.setOnAction(event -> {
+            classifiers.remove(classifier);
+            config.setClassifiers(new ArrayList<>(classifiers));
+            classifierList.getChildren().remove(card);
+            notifyConfigChanged();
+        });
+
+        return card;
+    }
+
+    private Node buildPixelClassifierRow(PixelClassifierConfig classifier) {
+        TextField classifierField = new TextField();
+        classifierField.setPromptText("Select a .json classifier");
+        classifierField.setEditable(false);
+        classifierField.setText(formatPixelClassifierName(classifier.getClassifierName()));
+
+        Label badge = new Label();
+        updateClassifierBadge(badge, classifier.getRegionFilter());
+
+        Button browseButton = new Button("Browse...");
+        browseButton.setOnAction(event -> choosePixelClassifier(classifier, classifierField));
+
+        HBox classifierRow = new HBox(8, new Label("Classifier"), classifierField, badge, browseButton);
+        classifierRow.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(classifierField, Priority.ALWAYS);
+
+        TextField measurementField = new TextField();
+        measurementField.setPromptText("Measurement ID (e.g. red_projections)");
+        measurementField.setText(Optional.ofNullable(classifier.getMeasurementId()).orElse(""));
+        measurementField.textProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            String trimmed = value != null ? value.trim() : "";
+            classifier.setMeasurementId(trimmed.isEmpty() ? null : trimmed);
+            notifyConfigChanged();
+        });
+
+        TextField regionField = new TextField(formatRegionFilter(classifier.getRegionFilter()));
+        regionField.setPromptText("Restrict to regions (optional)");
+        addTooltip(regionField, TOOLTIP_PIXEL_CLASSIFIER_REGIONS);
+        regionField.textProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdatingSupplier.getAsBoolean()) {
+                return;
+            }
+            List<String> parsed = parseRegionFilter(value);
+            classifier.setRegionFilter(parsed.isEmpty() ? null : parsed);
+            updateClassifierBadge(badge, classifier.getRegionFilter());
+            config.setPixelClassifiers(new ArrayList<>(pixelClassifiers));
+            notifyConfigChanged();
+        });
+
+        Button removeButton = new Button("Remove");
+
+        HBox measurementRow = new HBox(8, new Label("Measurement"), measurementField, removeButton);
+        measurementRow.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(measurementField, Priority.ALWAYS);
+
+        HBox regionRow = new HBox(8, new Label("Region Filter"), regionField);
+        regionRow.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(regionField, Priority.ALWAYS);
+
+        VBox card = new VBox(8, classifierRow, measurementRow, regionRow);
+        card.setPadding(new Insets(10));
+        card.setStyle("-fx-background-color: -fx-control-inner-background;"
+                + "-fx-background-radius: 6;"
+                + "-fx-border-color: -fx-box-border;"
+                + "-fx-border-radius: 6;");
+
+        removeButton.setOnAction(event -> {
+            pixelClassifiers.remove(classifier);
+            config.setPixelClassifiers(new ArrayList<>(pixelClassifiers));
+            pixelClassifierList.getChildren().remove(card);
+            notifyConfigChanged();
+        });
+
+        return card;
+    }
+
+    private void addClassifierFromChooser() {
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Select classifier");
+        chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("QuPath classifier", "*.json"));
+        File selected = chooser.showOpenDialog(owner);
+        if (selected == null) {
+            return;
+        }
+        Path selectedPath = selected.toPath();
+        Path targetDir = resolveClassifierTargetDir();
+        if (targetDir == null) {
+            Dialogs.showErrorMessage("BraiAnDetect", "No project directory is available for classifier storage.");
+            return;
+        }
+
+        if (!isUnderAllowedRoot(selectedPath)) {
+            boolean copy = Dialogs.showConfirmDialog(
+                    "Copy classifier",
+                    "Copy classifier to " + targetDir
+                            + "? BraiAn requires classifiers to be stored in the project or its parent folder.");
+            if (!copy) {
+                return;
+            }
+            Path targetPath = targetDir.resolve(selected.getName());
+            try {
+                Files.copy(selectedPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                Dialogs.showErrorMessage("BraiAnDetect", "Failed to copy classifier: " + e.getMessage());
+                return;
+            }
+            selectedPath = targetPath;
+        }
+
+        ChannelClassifierConfig classifier = new ChannelClassifierConfig();
+        classifier.setName(stripJsonExtension(selectedPath.getFileName().toString()));
+        classifiers.add(classifier);
+        config.setClassifiers(new ArrayList<>(classifiers));
+        classifierList.getChildren().add(buildClassifierRow(classifier));
+        notifyConfigChanged();
+    }
+
+    private void addPixelClassifierCard() {
+        PixelClassifierConfig classifier = new PixelClassifierConfig();
+        pixelClassifiers.add(classifier);
+        config.setPixelClassifiers(new ArrayList<>(pixelClassifiers));
+        pixelClassifierList.getChildren().add(buildPixelClassifierRow(classifier));
+        notifyConfigChanged();
+    }
+
+    private void choosePixelClassifier(PixelClassifierConfig config, TextField classifierField) {
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Select pixel classifier");
+        chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("QuPath classifier", "*.json"));
+        File selected = chooser.showOpenDialog(owner);
+        if (selected == null) {
+            return;
+        }
+        Path selectedPath = selected.toPath();
+        Path targetDir = resolveClassifierTargetDir();
+        if (targetDir == null) {
+            Dialogs.showErrorMessage("BraiAnDetect", "No project directory is available for classifier storage.");
+            return;
+        }
+
+        if (!isUnderAllowedRoot(selectedPath)) {
+            boolean copy = Dialogs.showConfirmDialog(
+                    "Copy classifier",
+                    "Copy classifier to " + targetDir
+                            + "? BraiAn requires classifiers to be stored in the project or its parent folder.");
+            if (!copy) {
+                return;
+            }
+            Path targetPath = targetDir.resolve(selected.getName());
+            try {
+                Files.copy(selectedPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                Dialogs.showErrorMessage("BraiAnDetect", "Failed to copy classifier: " + e.getMessage());
+                return;
+            }
+            selectedPath = targetPath;
+        }
+
+        String baseName = stripJsonExtension(selectedPath.getFileName().toString());
+        config.setClassifierName(baseName);
+        classifierField.setText(baseName + ".json");
+        notifyConfigChanged();
+    }
+
+    private Path resolveClassifierTargetDir() {
+        Path configRoot = configRootSupplier.get();
+        if (configRoot != null) {
+            return configRoot;
+        }
+        return projectDirSupplier.get();
+    }
+
+    private boolean isUnderAllowedRoot(Path path) {
+        for (Path root : resolveClassifierRoots()) {
+            if (root != null && path.normalize().startsWith(root.normalize())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<Path> resolveClassifierRoots() {
+        List<Path> roots = new ArrayList<>();
+        Path configRoot = configRootSupplier.get();
+        if (configRoot != null) {
+            roots.add(configRoot);
+        }
+        Path projectDir = projectDirSupplier.get();
+        if (projectDir != null && !projectDir.equals(configRoot)) {
+            roots.add(projectDir);
+        }
+        return roots;
+    }
+
+    private String stripJsonExtension(String fileName) {
+        if (fileName.toLowerCase().endsWith(".json")) {
+            return fileName.substring(0, fileName.length() - 5);
+        }
+        return fileName;
+    }
+
+    private String formatPixelClassifierName(String classifierName) {
+        if (classifierName == null || classifierName.isBlank()) {
+            return "";
+        }
+        return classifierName + ".json";
+    }
+
+    private List<String> parseAnnotations(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        String[] parts = value.split(",");
+        List<String> results = new ArrayList<>();
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (!trimmed.isEmpty()) {
+                results.add(trimmed);
+            }
+        }
+        return results;
+    }
+
+    private List<String> parseRegionFilter(String value) {
+        return parseAnnotations(value);
+    }
+
+    private String formatAnnotations(List<String> annotations) {
+        if (annotations == null || annotations.isEmpty()) {
+            return "";
+        }
+        return String.join(", ", annotations);
+    }
+
+    private String formatRegionFilter(List<String> regionFilter) {
+        return formatAnnotations(regionFilter);
+    }
+
+    private void notifyConfigChanged() {
+        if (!isUpdatingSupplier.getAsBoolean()) {
+            onConfigChanged.run();
+        }
+    }
+
+    private void notifyChannelNameChanged() {
+        if (!isUpdatingSupplier.getAsBoolean()) {
+            onChannelNameChanged.run();
+        }
+    }
+}

--- a/src/main/java/qupath/ext/braian/gui/ExclusionReviewDialog.java
+++ b/src/main/java/qupath/ext/braian/gui/ExclusionReviewDialog.java
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.gui;
+
+import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.ext.braian.AtlasManager;
+import qupath.ext.braian.ExclusionReport;
+import qupath.fx.dialogs.Dialogs;
+import qupath.fx.utils.FXUtils;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathAnnotationObject;
+import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+import qupath.lib.projects.Project;
+import qupath.lib.projects.ProjectIO;
+import qupath.lib.projects.ProjectImageEntry;
+import qupath.lib.projects.Projects;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Dialog for reviewing excluded regions across project entries.
+ * <p>
+ * This dialog displays a table of {@link ExclusionReport} items, allows
+ * navigation to an excluded annotation,
+ * and supports restoring regions by removing the corresponding
+ * {@link AtlasManager#EXCLUDE_CLASSIFICATION} annotation.
+ */
+public class ExclusionReviewDialog extends Stage {
+    private static final Logger logger = LoggerFactory.getLogger(ExclusionReviewDialog.class);
+    private static final DecimalFormat DECIMAL_FMT = new DecimalFormat("0.00");
+
+    private final QuPathGUI qupath;
+    private final TableView<ExclusionReport> table = new TableView<>();
+    private final ObservableList<ExclusionReport> reports;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    /**
+     * Creates a new review dialog.
+     *
+     * @param qupath  the QuPath GUI instance
+     * @param reports the exclusion reports to display
+     */
+    public ExclusionReviewDialog(QuPathGUI qupath, List<ExclusionReport> reports) {
+        this.qupath = qupath;
+        this.reports = FXCollections.observableArrayList(reports);
+
+        setTitle("Excluded Regions Review");
+        initOwner(qupath.getStage());
+        setWidth(860);
+        setHeight(520);
+
+        table.setItems(this.reports);
+        table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
+
+        TableColumn<ExclusionReport, String> imageCol = new TableColumn<>("Image");
+        imageCol.setCellValueFactory(data -> new ReadOnlyStringWrapper(data.getValue().imageLabel()));
+
+        TableColumn<ExclusionReport, String> regionCol = new TableColumn<>("Region Name");
+        regionCol.setCellValueFactory(data -> {
+            String name = data.getValue().regionName();
+            if (name == null || name.isBlank()) {
+                name = "(unnamed)";
+            }
+            return new ReadOnlyStringWrapper(name);
+        });
+
+        TableColumn<ExclusionReport, String> percentileCol = new TableColumn<>("Percentile");
+        percentileCol.setCellValueFactory(data -> {
+            double v = data.getValue().percentile();
+            if (Double.isNaN(v)) {
+                return new ReadOnlyStringWrapper("n/a");
+            }
+            return new ReadOnlyStringWrapper(DECIMAL_FMT.format(v) + "%");
+        });
+        percentileCol.setMaxWidth(120);
+        percentileCol.setMinWidth(120);
+        percentileCol.setCellFactory(col -> new TableCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                setText(empty ? null : item);
+                setAlignment(Pos.CENTER_RIGHT);
+            }
+        });
+
+        table.getColumns().addAll(imageCol, regionCol, percentileCol);
+        table.setRowFactory(tv -> {
+            TableRow<ExclusionReport> row = new TableRow<>();
+            row.setOnMouseClicked(e -> {
+                if (e.getClickCount() == 2 && !row.isEmpty()) {
+                    navigateTo(row.getItem());
+                }
+            });
+            return row;
+        });
+
+        Label hint = new Label(
+                "Double-click a row to navigate. Use 'Restore Selected' to remove the Exclude annotation.");
+        hint.setPadding(new Insets(0, 0, 8, 0));
+
+        Button restore = new Button("Restore Selected");
+        restore.disableProperty().bind(table.getSelectionModel().selectedItemProperty().isNull());
+        restore.setOnAction(e -> restoreSelected());
+
+        Button close = new Button("Close");
+        close.setOnAction(e -> close());
+
+        HBox buttons = new HBox(10, restore, close);
+        buttons.setAlignment(Pos.CENTER_RIGHT);
+
+        BorderPane root = new BorderPane();
+        root.setPadding(new Insets(12));
+        root.setTop(hint);
+        root.setCenter(table);
+        root.setBottom(buttons);
+        BorderPane.setMargin(buttons, new Insets(10, 0, 0, 0));
+
+        setScene(new Scene(root));
+
+        setOnHidden(e -> executor.shutdown());
+    }
+
+    private void navigateTo(ExclusionReport report) {
+        // Check if we're already viewing this image
+        ImageData<BufferedImage> current = qupath.getViewer() != null ? qupath.getViewer().getImageData() : null;
+        if (current != null) {
+            String currentImageName = current.getServerMetadata().getName();
+            boolean sameProject = report.projectFile() == null || isCurrentProject(report.projectFile());
+            if (sameProject && currentImageName.equals(report.imageName())) {
+                // Already viewing this image, just select and center
+                Platform.runLater(() -> selectAndCenter(current, report.excludedAnnotationId()));
+                return;
+            }
+        }
+
+        executor.execute(() -> {
+            try {
+                LoadedImage loaded = loadImageForReport(report);
+                if (loaded == null) {
+                    return;
+                }
+                Platform.runLater(() -> {
+                    try {
+                        qupath.getViewer().setImageData(loaded.imageData);
+                        selectAndCenter(loaded.imageData, report.excludedAnnotationId());
+                    } catch (IOException e) {
+                        Dialogs.showErrorMessage("Open image", resolveErrorMessage(e));
+                    }
+                });
+            } catch (Exception e) {
+                logger.error("Navigation failed", e);
+                Platform.runLater(() -> Dialogs.showErrorMessage("Navigate", resolveErrorMessage(e)));
+            }
+        });
+    }
+
+    private void restoreSelected() {
+        List<ExclusionReport> selected = List.copyOf(table.getSelectionModel().getSelectedItems());
+        if (selected.isEmpty()) {
+            return;
+        }
+
+        executor.execute(() -> {
+            for (ExclusionReport report : selected) {
+                try {
+                    restoreOne(report);
+                    Platform.runLater(() -> reports.remove(report));
+                } catch (Exception e) {
+                    logger.error("Restore failed", e);
+                    Platform.runLater(() -> Dialogs.showErrorMessage("Restore", resolveErrorMessage(e)));
+                    break;
+                }
+            }
+        });
+    }
+
+    private void restoreOne(ExclusionReport report) throws IOException {
+        ImageData<BufferedImage> current = qupath.getViewer() != null ? qupath.getViewer().getImageData() : null;
+        if (current != null) {
+            Project<BufferedImage> currentProject = qupath.getProject();
+            ProjectImageEntry<BufferedImage> currentEntry = currentProject != null ? currentProject.getEntry(current)
+                    : null;
+            String currentName = currentEntry != null ? currentEntry.getImageName()
+                    : current.getServerMetadata().getName();
+
+            boolean sameProject = report.projectFile() == null || isCurrentProject(report.projectFile());
+            if (sameProject && currentName.equals(report.imageName())) {
+                boolean removed = removeExcludeById(current.getHierarchy(), report.excludedAnnotationId());
+                if (removed && currentEntry != null) {
+                    currentEntry.saveImageData(current);
+                }
+                return;
+            }
+        }
+
+        LoadedImage loaded = loadImageForReport(report);
+        if (loaded == null) {
+            throw new IOException("Unable to load image for restore");
+        }
+
+        boolean removed = removeExcludeById(loaded.imageData.getHierarchy(), report.excludedAnnotationId());
+        if (!removed) {
+            return;
+        }
+        loaded.entry.saveImageData(loaded.imageData);
+        try {
+            loaded.imageData.getServer().close();
+        } catch (Exception e) {
+            logger.warn("Failed to close image server after restore: {}", e.getMessage());
+        }
+        try {
+            loaded.project.syncChanges();
+        } catch (Exception e) {
+            logger.warn("Failed to sync project after restore: {}", e.getMessage());
+        }
+    }
+
+    private void selectAndCenter(ImageData<BufferedImage> imageData, UUID annotationId) {
+        if (imageData == null || annotationId == null) {
+            return;
+        }
+        PathObjectHierarchy hierarchy = imageData.getHierarchy();
+        PathAnnotationObject target = findAnnotationById(hierarchy, annotationId);
+        if (target == null) {
+            return;
+        }
+        hierarchy.getSelectionModel().clearSelection();
+        hierarchy.getSelectionModel().setSelectedObject(target);
+        var roi = target.getROI();
+        if (roi != null && qupath.getViewer() != null) {
+            qupath.getViewer().setCenterPixelLocation(roi.getCentroidX(), roi.getCentroidY());
+        }
+    }
+
+    private static boolean removeExcludeById(PathObjectHierarchy hierarchy, UUID annotationId) {
+        PathAnnotationObject target = findAnnotationById(hierarchy, annotationId);
+        if (target == null) {
+            return false;
+        }
+        if (target.getPathClass() != AtlasManager.EXCLUDE_CLASSIFICATION) {
+            return false;
+        }
+        hierarchy.removeObject(target, true);
+        return true;
+    }
+
+    private static PathAnnotationObject findAnnotationById(PathObjectHierarchy hierarchy, UUID id) {
+        if (hierarchy == null || id == null) {
+            return null;
+        }
+        for (var ann : hierarchy.getAnnotationObjects()) {
+            if (id.equals(ann.getID()) && ann instanceof PathAnnotationObject) {
+                return (PathAnnotationObject) ann;
+            }
+        }
+        return null;
+    }
+
+    private boolean isCurrentProject(Path projectFile) {
+        Project<BufferedImage> project = qupath.getProject();
+        if (project == null) {
+            return false;
+        }
+        Path baseDir = Projects.getBaseDirectory(project).toPath();
+        return baseDir != null && projectFile.getParent() != null && baseDir.equals(projectFile.getParent());
+    }
+
+    private LoadedImage loadImageForReport(ExclusionReport report) throws IOException {
+        if (report.projectFile() == null) {
+            // Best effort: use current project
+            Project<BufferedImage> project = qupath.getProject();
+            if (project == null) {
+                return null;
+            }
+            var entry = findEntryByImageName(project, report.imageName());
+            if (entry == null) {
+                return null;
+            }
+            ImageData<BufferedImage> imageData = entry.readImageData();
+            return new LoadedImage(project, entry, imageData);
+        }
+
+        Project<BufferedImage> project = ProjectIO.loadProject(report.projectFile().toFile(), BufferedImage.class);
+        FXUtils.runOnApplicationThread(() -> qupath.setProject(project));
+
+        var entry = findEntryByImageName(project, report.imageName());
+        if (entry == null) {
+            return null;
+        }
+        ImageData<BufferedImage> imageData = entry.readImageData();
+        return new LoadedImage(project, entry, imageData);
+    }
+
+    private static ProjectImageEntry<BufferedImage> findEntryByImageName(Project<BufferedImage> project,
+            String imageName) {
+        if (project == null || imageName == null) {
+            return null;
+        }
+        for (ProjectImageEntry<BufferedImage> entry : project.getImageList()) {
+            if (imageName.equals(entry.getImageName())) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private static String resolveErrorMessage(Exception e) {
+        String message = e.getMessage();
+        if (message == null || message.isBlank()) {
+            return "Unexpected error. See log for details.";
+        }
+        return message;
+    }
+
+    private record LoadedImage(Project<BufferedImage> project,
+            ProjectImageEntry<BufferedImage> entry,
+            ImageData<BufferedImage> imageData) {
+    }
+}

--- a/src/main/java/qupath/ext/braian/gui/ExperimentPane.java
+++ b/src/main/java/qupath/ext/braian/gui/ExperimentPane.java
@@ -1,0 +1,525 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.gui;
+
+import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.Separator;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import qupath.ext.braian.config.AutoThresholdParmameters;
+import qupath.ext.braian.config.ChannelDetectionsConfig;
+import qupath.ext.braian.config.DetectionsCheckConfig;
+import qupath.ext.braian.config.ProjectsConfig;
+import qupath.ext.braian.config.WatershedCellDetectionConfig;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathAnnotationObject;
+import qupath.lib.projects.Project;
+import qupath.lib.projects.ProjectImageEntry;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Main pane used to configure and run the BraiAn analysis pipeline.
+ * <p>
+ * This component is responsible for editing {@link ProjectsConfig}, including
+ * global settings,
+ * per-channel parameters, and execution controls.
+ */
+public class ExperimentPane extends VBox {
+    private final ObservableList<String> channelNames;
+    private final List<String> availableImageChannels;
+    private final Stage owner;
+    private final BooleanProperty batchMode;
+    private final BooleanProperty batchReady;
+    private final BooleanProperty running;
+    private final Runnable onPreview;
+    private final Runnable onRun;
+    private final Runnable onConfigChanged;
+    private final Supplier<Path> configRootSupplier;
+    private final Supplier<Path> projectDirSupplier;
+    private final Supplier<Project<BufferedImage>> projectSupplier;
+    private final Supplier<ImageData<?>> imageDataSupplier;
+    private final VBox channelStack = new VBox(12);
+    private final TextField classForDetectionsField = new TextField();
+    private final TextField atlasNameField = new TextField();
+    private final CheckBox detectionsCheckBox = new CheckBox("Enforce Co-localization");
+    private final ComboBox<String> controlChannelCombo = new ComboBox<>();
+    private final Button addChannelButton = new Button("+ Add Channel");
+    private final BooleanProperty hasCellDetection = new SimpleBooleanProperty(false);
+    private final BooleanProperty hasPixelClassification = new SimpleBooleanProperty(false);
+    private ProjectsConfig config;
+    private boolean isUpdating = false;
+
+    private static final String HELP_URL_CROSS_CHANNEL = "https://silvalab.codeberg.page/BraiAn/image-analysis/#:~:text=Find%20co%2Dlabelled%20detections";
+    private static final String DEFAULT_ATLAS = "allen_mouse_10um_java";
+    private static final String ROOT_ANNOTATION_NAME = "Root";
+
+    /**
+     * Creates the experiment pane.
+     *
+     * @param config                 the initial configuration
+     * @param channelNames           observable list of available channel names
+     * @param availableImageChannels available image channel names from the current
+     *                               image
+     * @param owner                  owning stage used for dialogs
+     * @param batchMode              whether the analysis runs in batch mode
+     * @param batchReady             whether batch mode has a valid project
+     *                               selection
+     * @param running                indicates whether the pipeline is currently
+     *                               running
+     * @param onPreview              callback to run a preview on the current image
+     * @param onRun                  callback to run the pipeline
+     * @param onConfigChanged        callback invoked when configuration is changed
+     * @param configRootSupplier     supplier for the directory containing
+     *                               configuration resources
+     * @param projectDirSupplier     supplier for the current project directory
+     * @param projectSupplier        supplier for the current QuPath project
+     * @param imageDataSupplier      supplier for the current {@link ImageData}
+     */
+    public ExperimentPane(ProjectsConfig config,
+            ObservableList<String> channelNames,
+            List<String> availableImageChannels,
+            Stage owner,
+            BooleanProperty batchMode,
+            BooleanProperty batchReady,
+            BooleanProperty running,
+            Runnable onPreview,
+            Runnable onRun,
+            Runnable onConfigChanged,
+            Supplier<Path> configRootSupplier,
+            Supplier<Path> projectDirSupplier,
+            Supplier<Project<BufferedImage>> projectSupplier,
+            Supplier<ImageData<?>> imageDataSupplier) {
+        this.channelNames = channelNames;
+        this.availableImageChannels = availableImageChannels;
+        this.owner = owner;
+        this.batchMode = batchMode;
+        this.batchReady = batchReady;
+        this.running = running;
+        this.onPreview = Objects.requireNonNullElse(onPreview, () -> {
+        });
+        this.onRun = Objects.requireNonNullElse(onRun, () -> {
+        });
+        this.onConfigChanged = Objects.requireNonNullElse(onConfigChanged, () -> {
+        });
+        this.config = config;
+        this.configRootSupplier = configRootSupplier;
+        this.projectDirSupplier = projectDirSupplier;
+        this.projectSupplier = projectSupplier;
+        this.imageDataSupplier = imageDataSupplier;
+
+        setSpacing(16);
+        setPadding(new Insets(16));
+
+        getChildren().addAll(
+                buildGlobalSection(),
+                new Separator(),
+                buildChannelSection(),
+                new Separator(),
+                buildCommandBar());
+
+        ensureChannelListMutable();
+        refreshFromConfig();
+    }
+
+    /**
+     * Replaces the underlying configuration object and refreshes the UI.
+     *
+     * @param config the new configuration
+     */
+    public void setConfig(ProjectsConfig config) {
+        this.config = config;
+        ensureChannelListMutable();
+        refreshFromConfig();
+    }
+
+    private VBox buildGlobalSection() {
+        VBox section = new VBox(8);
+        Label header = new Label("Global Detection Settings");
+        classForDetectionsField.setPromptText("Restrict detection to this annotation class (optional)");
+        classForDetectionsField.textProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdating) {
+                return;
+            }
+            String trimmed = value != null ? value.trim() : "";
+            config.setClassForDetections(trimmed.isEmpty() ? null : trimmed);
+            notifyConfigChanged();
+        });
+
+        atlasNameField.setPromptText("Atlas name (e.g. allen_mouse_10um_java)");
+        atlasNameField.textProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdating) {
+                return;
+            }
+            String trimmed = value != null ? value.trim() : "";
+            config.setAtlasName(trimmed.isEmpty() ? DEFAULT_ATLAS : trimmed);
+            notifyConfigChanged();
+        });
+
+        // Auto-detect atlas from hierarchy if not already set or default
+        autoDetectAtlas();
+
+        HBox detectionsCheckRow = new HBox(12);
+        detectionsCheckRow.setAlignment(Pos.CENTER_LEFT);
+        detectionsCheckBox.selectedProperty().addListener((obs, oldValue, selected) -> {
+            if (isUpdating) {
+                return;
+            }
+            config.getDetectionsCheck().setApply(selected);
+            notifyConfigChanged();
+        });
+        detectionsCheckBox.disableProperty().bind(hasCellDetection.not());
+        controlChannelCombo.setItems(channelNames);
+        controlChannelCombo.setPromptText("Control channel");
+        controlChannelCombo.disableProperty()
+                .bind(Bindings.or(
+                        hasCellDetection.not(),
+                        Bindings.or(detectionsCheckBox.selectedProperty().not(), Bindings.isEmpty(channelNames))));
+        controlChannelCombo.valueProperty().addListener((obs, oldValue, value) -> {
+            if (isUpdating) {
+                return;
+            }
+            config.getDetectionsCheck().setControlChannel(value);
+            notifyConfigChanged();
+        });
+        detectionsCheckRow.getChildren().addAll(detectionsCheckBox, controlChannelCombo);
+
+        HBox crossChannelRow = new HBox(6);
+        crossChannelRow.setAlignment(Pos.CENTER_LEFT);
+        Label crossChannelLabel = new Label("Cross-channel logic");
+        Hyperlink crossChannelHelp = buildHelpLink(HELP_URL_CROSS_CHANNEL);
+        crossChannelRow.getChildren().addAll(crossChannelLabel, crossChannelHelp);
+
+        Button refreshAtlasButton = new Button("Refresh");
+        refreshAtlasButton.setOnAction(event -> refreshAtlasDetection());
+        refreshAtlasButton.disableProperty().bind(running);
+        HBox atlasRow = new HBox(8, atlasNameField, refreshAtlasButton);
+        atlasRow.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(atlasNameField, Priority.ALWAYS);
+
+        section.getChildren().addAll(header,
+                new Label("Region Filter:"), classForDetectionsField,
+                new Label("Atlas Name (Auto-detected):"), atlasRow,
+                crossChannelRow, detectionsCheckRow);
+        return section;
+    }
+
+    private VBox buildChannelSection() {
+        VBox section = new VBox(12);
+        Label header = new Label("Channel Configuration");
+        channelStack.setSpacing(12);
+        addChannelButton.setOnAction(event -> addChannelCard());
+        addChannelButton.disableProperty().bind(running);
+        section.getChildren().addAll(header, channelStack, addChannelButton);
+        return section;
+    }
+
+    private HBox buildCommandBar() {
+        HBox bar = new HBox(12);
+        bar.setAlignment(Pos.CENTER_RIGHT);
+        Button previewButton = new Button("Preview on Current Image");
+        Button runButton = new Button("Run Detection");
+        runButton.textProperty().bind(Bindings.when(batchMode).then("Run Batch Detection").otherwise("Run Detection"));
+        var noModesEnabled = hasCellDetection.not().and(hasPixelClassification.not());
+        var missingInputs = noModesEnabled;
+        var batchMissing = batchMode.and(batchReady.not());
+        previewButton.disableProperty().bind(running.or(missingInputs));
+        runButton.disableProperty().bind(running.or(missingInputs).or(batchMissing));
+        previewButton.setOnAction(event -> onPreview.run());
+        runButton.setOnAction(event -> onRun.run());
+        HBox.setHgrow(runButton, Priority.NEVER);
+        bar.getChildren().addAll(previewButton, runButton);
+        return bar;
+    }
+
+    private void refreshFromConfig() {
+        isUpdating = true;
+        classForDetectionsField.setText(Optional.ofNullable(config.getClassForDetections()).orElse(""));
+        atlasNameField.setText(Optional.ofNullable(config.getAtlasName()).orElse(DEFAULT_ATLAS));
+        DetectionsCheckConfig detectionsCheck = config.getDetectionsCheck();
+        detectionsCheckBox.setSelected(detectionsCheck.getApply());
+        rebuildChannelCards();
+        refreshChannelNames();
+        syncControlChannelSelection();
+        updateModeAvailability();
+        isUpdating = false;
+    }
+
+    private void rebuildChannelCards() {
+        channelStack.getChildren().clear();
+        for (ChannelDetectionsConfig channelConfig : config.getChannelDetections()) {
+            addChannelCard(channelConfig);
+        }
+    }
+
+    private void addChannelCard() {
+        ChannelDetectionsConfig channelConfig = new ChannelDetectionsConfig();
+        WatershedCellDetectionConfig params = channelConfig.getParameters();
+        params.setRequestedPixelSizeMicrons(1.0);
+        params.setHistogramThreshold(new AutoThresholdParmameters());
+        List<ChannelDetectionsConfig> configs = new ArrayList<>(config.getChannelDetections());
+        configs.add(channelConfig);
+        config.setChannelDetections(configs);
+        addChannelCard(channelConfig);
+        refreshChannelNames();
+        notifyConfigChanged();
+    }
+
+    private void addChannelCard(ChannelDetectionsConfig channelConfig) {
+        ChannelCard card = new ChannelCard(
+                channelConfig,
+                availableImageChannels,
+                owner,
+                configRootSupplier,
+                projectDirSupplier,
+                this::notifyConfigChanged,
+                this::refreshChannelNames,
+                () -> isUpdating,
+                imageDataSupplier);
+        card.setOnRemove(() -> removeChannelCard(card, channelConfig));
+        channelStack.getChildren().add(card);
+    }
+
+    private void removeChannelCard(ChannelCard card, ChannelDetectionsConfig channelConfig) {
+        List<ChannelDetectionsConfig> configs = new ArrayList<>(config.getChannelDetections());
+        configs.remove(channelConfig);
+        config.setChannelDetections(configs);
+        channelStack.getChildren().remove(card);
+        refreshChannelNames();
+        notifyConfigChanged();
+    }
+
+    private void refreshChannelNames() {
+        List<String> names = config.getChannelDetections().stream()
+                .filter(ChannelDetectionsConfig::isEnableCellDetection)
+                .map(ChannelDetectionsConfig::getName)
+                .filter(name -> name != null && !name.isBlank())
+                .toList();
+        channelNames.setAll(names);
+        syncControlChannelSelection();
+    }
+
+    private void syncControlChannelSelection() {
+        String configured = config.getDetectionsCheck().getControlChannel();
+        if (configured != null && channelNames.contains(configured)) {
+            controlChannelCombo.setValue(configured);
+            return;
+        }
+        if (!channelNames.isEmpty() && config.getDetectionsCheck().getApply()) {
+            controlChannelCombo.setValue(channelNames.get(0));
+            config.getDetectionsCheck().setControlChannel(controlChannelCombo.getValue());
+            notifyConfigChanged();
+            return;
+        }
+        controlChannelCombo.setValue(null);
+    }
+
+    private void ensureChannelListMutable() {
+        if (config.getChannelDetections() == null) {
+            config.setChannelDetections(new ArrayList<>());
+        } else {
+            try {
+                config.getChannelDetections().add(new ChannelDetectionsConfig());
+                config.getChannelDetections().remove(config.getChannelDetections().size() - 1);
+            } catch (UnsupportedOperationException ex) {
+                config.setChannelDetections(new ArrayList<>(config.getChannelDetections()));
+            }
+        }
+    }
+
+    private void notifyConfigChanged() {
+        if (!isUpdating) {
+            refreshChannelNames();
+            onConfigChanged.run();
+            updateModeAvailability();
+        }
+    }
+
+    private Hyperlink buildHelpLink(String url) {
+        Hyperlink link = new Hyperlink("(?)");
+        link.setOnAction(event -> QuPathGUI.openInBrowser(url));
+        link.setFocusTraversable(false);
+        return link;
+    }
+
+    private void updateModeAvailability() {
+        boolean cellEnabled = config.getChannelDetections().stream()
+                .anyMatch(channel -> channel.isEnableCellDetection()
+                        && channel.getName() != null
+                        && !channel.getName().isBlank());
+        boolean pixelEnabled = config.getChannelDetections().stream()
+                .anyMatch(channel -> channel.isEnablePixelClassification()
+                        && channel.getPixelClassifiers() != null
+                        && !channel.getPixelClassifiers().isEmpty()
+                        && channel.getName() != null
+                        && !channel.getName().isBlank());
+        hasCellDetection.set(cellEnabled);
+        hasPixelClassification.set(pixelEnabled);
+        if (!cellEnabled && detectionsCheckBox.isSelected()) {
+            detectionsCheckBox.setSelected(false);
+        }
+    }
+
+    /**
+     * Refreshes atlas auto-detection, ignoring any currently set atlas name.
+     */
+    public void refreshAtlasDetection() {
+        detectAtlas(true);
+    }
+
+    /**
+     * Tries to detect the atlas name from the current image, falling back to
+     * scanning project entries for an imported atlas root annotation.
+     */
+    public void autoDetectAtlas() {
+        detectAtlas(false);
+    }
+
+    private void detectAtlas(boolean force) {
+        if (!force && !shouldAutoDetect()) {
+            return;
+        }
+
+        String detected = findAtlasFromImage(imageDataSupplier.get());
+        if (detected != null) {
+            if (Platform.isFxApplicationThread()) {
+                applyDetectedAtlas(detected, force);
+            } else {
+                Platform.runLater(() -> applyDetectedAtlas(detected, force));
+            }
+            return;
+        }
+
+        Project<BufferedImage> project = projectSupplier.get();
+        if (project == null) {
+            return;
+        }
+
+        if (Platform.isFxApplicationThread()) {
+            Thread worker = new Thread(() -> {
+                String found = findAtlasFromProject(project);
+                if (found != null) {
+                    Platform.runLater(() -> applyDetectedAtlas(found, force));
+                }
+            }, "braian-atlas-detect");
+            worker.setDaemon(true);
+            worker.start();
+            return;
+        }
+
+        String found = findAtlasFromProject(project);
+        if (found != null) {
+            if (Platform.isFxApplicationThread()) {
+                applyDetectedAtlas(found, force);
+            } else {
+                Platform.runLater(() -> applyDetectedAtlas(found, force));
+            }
+        }
+    }
+
+    private boolean shouldAutoDetect() {
+        String current = config.getAtlasName();
+        if (current == null || current.isBlank()) {
+            return true;
+        }
+        if (DEFAULT_ATLAS.equals(current)) {
+            return true;
+        }
+        return "image".equalsIgnoreCase(current);
+    }
+
+    private void applyDetectedAtlas(String detected, boolean force) {
+        if (detected == null || detected.isBlank()) {
+            return;
+        }
+        if (!force && !shouldAutoDetect()) {
+            return;
+        }
+        String current = config.getAtlasName();
+        if (detected.equals(current)) {
+            return;
+        }
+        boolean previousUpdating = isUpdating;
+        isUpdating = true;
+        atlasNameField.setText(detected);
+        isUpdating = previousUpdating;
+        config.setAtlasName(detected);
+        notifyConfigChanged();
+    }
+
+    private String findAtlasFromImage(ImageData<?> imageData) {
+        if (imageData == null) {
+            return null;
+        }
+        for (var annotation : imageData.getHierarchy().getAnnotationObjects()) {
+            if (!(annotation instanceof PathAnnotationObject)) {
+                continue;
+            }
+            String name = annotation.getName();
+            // Use exact case-sensitive match for "Root" to align with AtlasManager.search()
+            if (!ROOT_ANNOTATION_NAME.equals(name)) {
+                continue;
+            }
+            if (annotation.getPathClass() == null) {
+                continue;
+            }
+            String atlasName = annotation.getPathClass().toString();
+            if (atlasName != null && !atlasName.isBlank()) {
+                return atlasName;
+            }
+        }
+        return null;
+    }
+
+    private String findAtlasFromProject(Project<BufferedImage> project) {
+        if (project == null) {
+            return null;
+        }
+        for (ProjectImageEntry<BufferedImage> entry : project.getImageList()) {
+            ImageData<BufferedImage> imageData;
+            try {
+                imageData = entry.readImageData();
+            } catch (IOException e) {
+                continue;
+            }
+            try {
+                String detected = findAtlasFromImage(imageData);
+                if (detected != null) {
+                    return detected;
+                }
+            } finally {
+                try {
+                    imageData.getServer().close();
+                } catch (Exception e) {
+                    // Best effort cleanup.
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/qupath/ext/braian/utils/ProjectDiscoveryService.java
+++ b/src/main/java/qupath/ext/braian/utils/ProjectDiscoveryService.java
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.projects.ProjectIO;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Utilities for discovering QuPath project files on disk.
+ */
+public final class ProjectDiscoveryService {
+    private static final Logger logger = LoggerFactory.getLogger(ProjectDiscoveryService.class);
+
+    private ProjectDiscoveryService() {
+    }
+
+    /**
+     * Discover QuPath project files in the immediate subdirectories of
+     * {@code rootPath}.
+     *
+     * <p>
+     * Discovery rule: include {@code <subdir>/project.<ext>} where {@code <ext>} is
+     * {@link ProjectIO#DEFAULT_PROJECT_EXTENSION}.
+     *
+     * @param rootPath root directory to search
+     * @return list of discovered project files, sorted by directory name
+     */
+    public static List<Path> discoverProjectFiles(Path rootPath) {
+        if (rootPath == null || !Files.isDirectory(rootPath)) {
+            return List.of();
+        }
+
+        String extension = ProjectIO.DEFAULT_PROJECT_EXTENSION;
+        List<Path> results = new ArrayList<>();
+
+        try (var dirStream = Files.list(rootPath)) {
+            dirStream
+                    .filter(Files::isDirectory)
+                    .forEach(dir -> {
+                        Path projectFile = dir.resolve("project." + extension);
+                        if (Files.exists(projectFile)) {
+                            results.add(projectFile);
+                        }
+                    });
+        } catch (IOException e) {
+            logger.warn("Failed to discover projects under {}", rootPath, e);
+            return List.of();
+        }
+
+        results.sort(Comparator.comparing(path -> path.getParent().getFileName().toString()));
+        return results;
+    }
+}


### PR DESCRIPTION
Adds a JavaFX-based GUI for configuring and running the BraiAnDetect analysis pipeline, accessible via Extensions → BraiAn.

### Motivation

Currently, running the BraiAnDetect pipeline requires writing Groovy scripts and manually editing YAML files. This GUI provides a visual interface for the same workflow, lowering the barrier for new users while preserving the script-based approach for advanced users.

### New classes

| Class | Lines | Purpose |
|-------|-------|---------|
| `ExperimentPane` | 525 | Project discovery and experiment selection |
| `ChannelCard` | 937 | Per-channel detection configuration card |
| `ExclusionReviewDialog` | 349 | Review and undo auto-excluded regions |
| `BraiAnDetectDialog` | 914 | Main two-tab pipeline manager dialog |
| `ProjectDiscoveryService` | 64 | Scans directories for QuPath projects |

### Modified

- `BraiAnExtension` — register menu entries for the pipeline manager

### Dependencies

> **Important**: This PR depends on APIs introduced in:
> - PR 4 (`ExclusionReport`, `autoExcludeEmptyRegions`)
> - PR 6 (explicit context passing in `AtlasManager`, `ChannelDetections`, etc.)
>
> It will compile cleanly once those PRs are merged.

### Build

`./gradlew compileJava` ⚠️ requires PR 4 + PR 6

_Part of the PR #7 split — see #7 for full context._