### PR TITLE
feat: add batch runner classes for pipeline automation

### DIFF
--- a/src/main/java/qupath/ext/braian/runners/ABBAImporterRunner.java
+++ b/src/main/java/qupath/ext/braian/runners/ABBAImporterRunner.java
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.runners;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import qupath.fx.utils.FXUtils;
+import qupath.ext.braian.utils.ProjectDiscoveryService;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.commands.Commands;
+import qupath.lib.images.ImageData;
+import qupath.lib.projects.Project;
+import qupath.lib.projects.ProjectIO;
+import qupath.lib.projects.ProjectImageEntry;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.List;
+
+/**
+ * Runner for importing warped atlas annotations from the ABBA extension.
+ * <p>
+ * This class provides helpers to import the atlas for the current image, the
+ * current project, or
+ * for a batch of QuPath projects.
+ */
+public final class ABBAImporterRunner {
+    private static final Logger logger = LoggerFactory.getLogger(ABBAImporterRunner.class);
+
+    private static final String NAMING_PROPERTY = "acronym";
+    private static final boolean SPLIT_LEFT_RIGHT = true;
+    private static final boolean OVERWRITE = true;
+
+    private ABBAImporterRunner() {
+    }
+
+    /**
+     * Imports the atlas into the image currently open in QuPath.
+     *
+     * @param qupath the QuPath GUI instance
+     * @throws IllegalStateException if no image is open or if the ABBA extension is
+     *                               not available
+     */
+    public static void runCurrentImage(QuPathGUI qupath) {
+        if (!AbbaReflectionBridge.isAvailable()) {
+            throw new IllegalStateException(AbbaReflectionBridge.getFailureReason());
+        }
+        ImageData<BufferedImage> imageData = qupath.getViewer() != null ? qupath.getViewer().getImageData() : null;
+        if (imageData == null) {
+            throw new IllegalStateException("No image is currently open.");
+        }
+
+        importAtlas(imageData);
+        Project<BufferedImage> project = qupath.getProject();
+        if (project != null) {
+            ProjectImageEntry<BufferedImage> entry = project.getEntry(imageData);
+            if (entry != null) {
+                try {
+                    entry.saveImageData(imageData);
+                } catch (IOException e) {
+                    logger.warn("Failed to save image data after import: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Imports the atlas into every image entry of the current QuPath project.
+     *
+     * @param qupath the QuPath GUI instance
+     * @throws IllegalStateException if no project is open or if the ABBA extension
+     *                               is not available
+     */
+    public static void runProject(QuPathGUI qupath) {
+        if (!AbbaReflectionBridge.isAvailable()) {
+            throw new IllegalStateException(AbbaReflectionBridge.getFailureReason());
+        }
+        Project<BufferedImage> project = qupath.getProject();
+        if (project == null) {
+            throw new IllegalStateException("No project open.");
+        }
+
+        for (ProjectImageEntry<BufferedImage> entry : project.getImageList()) {
+            ImageData<BufferedImage> imageData;
+            try {
+                imageData = entry.readImageData();
+            } catch (IOException e) {
+                logger.error("Failed to read image data {}: {}", entry.getImageName(), e.getMessage());
+                continue;
+            }
+            try {
+                importAtlas(imageData);
+                entry.saveImageData(imageData);
+            } catch (Exception e) {
+                logger.error("Failed to import atlas for {}: {}", entry.getImageName(), e.getMessage());
+            } finally {
+                closeServer(imageData);
+            }
+        }
+
+        try {
+            project.syncChanges();
+        } catch (Exception e) {
+            logger.warn("Failed to sync project {}: {}", project.getName(), e.getMessage());
+        }
+        System.gc();
+    }
+
+    /**
+     * Discovers QuPath projects under {@code rootPath} and imports the atlas into
+     * each of them.
+     *
+     * @param qupath   the QuPath GUI instance
+     * @param rootPath root directory containing QuPath projects
+     * @throws IllegalArgumentException if {@code rootPath} is invalid
+     * @throws IllegalStateException    if no projects are found or if the ABBA
+     *                                  extension is not available
+     * @see ProjectDiscoveryService#discoverProjectFiles(Path)
+     */
+    public static void runBatch(QuPathGUI qupath, Path rootPath) {
+        if (!AbbaReflectionBridge.isAvailable()) {
+            throw new IllegalStateException(AbbaReflectionBridge.getFailureReason());
+        }
+        if (rootPath == null || !Files.isDirectory(rootPath)) {
+            throw new IllegalArgumentException("Invalid projects directory: " + rootPath);
+        }
+        List<Path> projectFiles = ProjectDiscoveryService.discoverProjectFiles(rootPath);
+        if (projectFiles.isEmpty()) {
+            throw new IllegalStateException("No QuPath projects found in " + rootPath);
+        }
+
+        runBatch(qupath, projectFiles);
+    }
+
+    /**
+     * Imports the atlas into a batch of QuPath projects.
+     *
+     * @param qupath       the QuPath GUI instance
+     * @param projectFiles list of QuPath project files (e.g.
+     *                     {@code project.qpproj})
+     * @throws IllegalArgumentException if {@code projectFiles} is null or empty
+     * @throws IllegalStateException    if the ABBA extension is not available
+     */
+    public static void runBatch(QuPathGUI qupath, List<Path> projectFiles) {
+        if (!AbbaReflectionBridge.isAvailable()) {
+            throw new IllegalStateException(AbbaReflectionBridge.getFailureReason());
+        }
+        if (projectFiles == null || projectFiles.isEmpty()) {
+            throw new IllegalArgumentException("No project files provided.");
+        }
+
+        // BraiAn Config is not needed for Atlas import
+
+        for (Path projectFile : projectFiles) {
+            Project<BufferedImage> project;
+            try {
+                project = ProjectIO.loadProject(projectFile.toFile(), BufferedImage.class);
+            } catch (IOException e) {
+                logger.error("Failed to load project {}: {}", projectFile, e.getMessage());
+                continue;
+            }
+            FXUtils.runOnApplicationThread(() -> qupath.setProject(project));
+
+            for (ProjectImageEntry<BufferedImage> entry : project.getImageList()) {
+                ImageData<BufferedImage> imageData;
+                try {
+                    imageData = entry.readImageData();
+                } catch (IOException e) {
+                    logger.error("Failed to read image data {}: {}", entry.getImageName(), e.getMessage());
+                    continue;
+                }
+                try {
+                    importAtlas(imageData);
+                    entry.saveImageData(imageData);
+                } catch (Exception e) {
+                    logger.error("Failed to import atlas for {}: {}", entry.getImageName(), e.getMessage());
+                } finally {
+                    closeServer(imageData);
+                }
+            }
+
+            try {
+                project.syncChanges();
+            } catch (Exception e) {
+                logger.warn("Failed to sync project {}: {}", projectFile, e.getMessage());
+            }
+            System.gc();
+            FXUtils.runOnApplicationThread(() -> Commands.closeProject(qupath));
+        }
+    }
+
+    private static void importAtlas(ImageData<BufferedImage> imageData) {
+        imageData.setImageType(ImageData.ImageType.FLUORESCENCE);
+        imageData.getHierarchy().clearAll();
+        AbbaReflectionBridge.loadWarpedAtlasAnnotations(imageData, null, NAMING_PROPERTY, SPLIT_LEFT_RIGHT,
+                OVERWRITE);
+    }
+
+    private static void closeServer(ImageData<BufferedImage> imageData) {
+        try {
+            imageData.getServer().close();
+        } catch (Exception e) {
+            logger.warn("Failed to close image server: {}", e.getMessage());
+        }
+    }
+
+    // Project file discovery is delegated to ProjectDiscoveryService.
+}

--- a/src/main/java/qupath/ext/braian/runners/AbbaReflectionBridge.java
+++ b/src/main/java/qupath/ext/braian/runners/AbbaReflectionBridge.java
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.runners;
+
+import qupath.lib.images.ImageData;
+
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Method;
+
+final class AbbaReflectionBridge {
+    private static final String[] ATLAS_TOOL_CLASSES = {
+            "qupath.ext.biop.abba.AtlasTools",
+            "ch.epfl.biop.qupath.atlas.allen.api.AtlasTools"
+    };
+    private static final String METHOD_NAME = "loadWarpedAtlasAnnotations";
+    private static volatile boolean resolved = false;
+    private static Method loadMethod;
+    private static String failureReason;
+
+    private AbbaReflectionBridge() {
+    }
+
+    static boolean isAvailable() {
+        resolve();
+        return loadMethod != null;
+    }
+
+    static String getFailureReason() {
+        resolve();
+        if (failureReason != null) {
+            return failureReason;
+        }
+        return "ABBA extension is not available.";
+    }
+
+    static void loadWarpedAtlasAnnotations(ImageData<BufferedImage> imageData,
+            String atlasName,
+            String namingProperty,
+            boolean splitLeftRight,
+            boolean overwrite) {
+        resolve();
+        if (loadMethod == null) {
+            throw new IllegalStateException(getFailureReason());
+        }
+        try {
+            int paramCount = loadMethod.getParameterCount();
+            if (paramCount == 3) {
+                loadMethod.invoke(null, imageData, namingProperty, splitLeftRight);
+            } else if (paramCount == 5) {
+                String resolvedAtlas = (atlasName == null || atlasName.isBlank()) ? "allen_mouse_10um_java" : atlasName;
+                loadMethod.invoke(null, imageData, resolvedAtlas, namingProperty, splitLeftRight, overwrite);
+            } else {
+                throw new IllegalStateException("Unsupported ABBA AtlasTools signature");
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("ABBA import failed: " + e.getMessage(), e);
+        }
+    }
+
+    private static void resolve() {
+        if (resolved) {
+            return;
+        }
+        synchronized (AbbaReflectionBridge.class) {
+            if (resolved) {
+                return;
+            }
+            for (String className : ATLAS_TOOL_CLASSES) {
+                try {
+                    Class<?> atlasTools = Class.forName(className);
+                    Method method = findMethod(atlasTools);
+                    if (method != null) {
+                        loadMethod = method;
+                        failureReason = null;
+                        resolved = true;
+                        return;
+                    }
+                    failureReason = "ABBA AtlasTools method not found in " + className + ".";
+                } catch (ClassNotFoundException e) {
+                    failureReason = "ABBA extension is not installed.";
+                }
+            }
+            resolved = true;
+        }
+    }
+
+    private static Method findMethod(Class<?> atlasTools) {
+        try {
+            return atlasTools.getMethod(METHOD_NAME, ImageData.class, String.class, boolean.class);
+        } catch (NoSuchMethodException ignored) {
+        }
+        try {
+            return atlasTools.getMethod(METHOD_NAME, ImageData.class, String.class, String.class, boolean.class,
+                    boolean.class);
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/qupath/ext/braian/runners/AutoExcludeEmptyRegionsRunner.java
+++ b/src/main/java/qupath/ext/braian/runners/AutoExcludeEmptyRegionsRunner.java
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.runners;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.ext.braian.AtlasManager;
+import qupath.ext.braian.ExclusionReport;
+import qupath.fx.utils.FXUtils;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.commands.Commands;
+import qupath.lib.images.ImageData;
+import qupath.lib.projects.Project;
+import qupath.lib.projects.ProjectIO;
+import qupath.lib.projects.ProjectImageEntry;
+import qupath.lib.projects.Projects;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runner for automatically excluding empty atlas regions.
+ * <p>
+ * This class orchestrates
+ * {@link AtlasManager#autoExcludeEmptyRegions(ImageData, List, Map)}
+ * across different scopes
+ * (current image, current project, or a batch of projects) and ensures results
+ * are persisted.
+ */
+public final class AutoExcludeEmptyRegionsRunner {
+    private static final Logger logger = LoggerFactory.getLogger(AutoExcludeEmptyRegionsRunner.class);
+
+    private AutoExcludeEmptyRegionsRunner() {
+    }
+
+    /**
+     * Runs auto-exclusion on the image currently open in QuPath.
+     *
+     * @param qupath               the QuPath GUI instance
+     * @param channelNames         the list of channel names to evaluate
+     * @param useMaxAcrossChannels if true, use the max intensity across channels
+     * @param thresholdMultiplier  multiplier applied to the adaptive threshold
+     * @return the list of excluded regions for the current image
+     * @throws IllegalStateException if no image is open
+     */
+    public static List<ExclusionReport> runCurrentImage(
+            QuPathGUI qupath,
+            List<String> channelNames,
+            boolean useMaxAcrossChannels,
+            double thresholdMultiplier) {
+        ImageData<BufferedImage> imageData = qupath.getViewer() != null ? qupath.getViewer().getImageData() : null;
+        if (imageData == null) {
+            throw new IllegalStateException("No image is currently open.");
+        }
+
+        Project<BufferedImage> project = qupath.getProject();
+        ProjectImageEntry<BufferedImage> entry = project != null ? project.getEntry(imageData) : null;
+        Path projectFile = project != null
+                ? Projects.getBaseDirectory(project).toPath().resolve("project." + ProjectIO.DEFAULT_PROJECT_EXTENSION)
+                : null;
+        String projectName = project != null ? project.getName() : null;
+        String imageName = entry != null ? entry.getImageName() : imageData.getServerMetadata().getName();
+
+        List<ExclusionReport> reports;
+        try {
+            AtlasManager atlas = new AtlasManager(imageData.getHierarchy());
+            reports = atlas.autoExcludeEmptyRegions(imageData, channelNames, useMaxAcrossChannels, thresholdMultiplier);
+        } catch (Exception e) {
+            throw new IllegalStateException("Auto-exclusion failed for " + imageName + ": " + e.getMessage(), e);
+        }
+
+        List<ExclusionReport> withContext = reports.stream()
+                .map(r -> new ExclusionReport(projectFile, projectName, imageName, r.excludedAnnotationId(),
+                        r.regionName(), r.percentile()))
+                .toList();
+
+        if (entry != null) {
+            try {
+                entry.saveImageData(imageData);
+            } catch (IOException e) {
+                logger.warn("Failed to save image data after auto-exclusion: {}", e.getMessage());
+            }
+        }
+        return withContext;
+    }
+
+    /**
+     * Runs auto-exclusion for every entry of the current QuPath project.
+     *
+     * @param qupath               the QuPath GUI instance
+     * @param channelNames         the list of channel names to evaluate
+     * @param useMaxAcrossChannels if true, use the max intensity across channels
+     * @param thresholdMultiplier  multiplier applied to the adaptive threshold
+     * @return a flattened list of excluded regions for all entries
+     * @throws IllegalStateException if no project is open
+     */
+    public static List<ExclusionReport> runProject(
+            QuPathGUI qupath,
+            List<String> channelNames,
+            boolean useMaxAcrossChannels,
+            double thresholdMultiplier) {
+        Project<BufferedImage> project = qupath.getProject();
+        if (project == null) {
+            throw new IllegalStateException("No project open.");
+        }
+
+        Path projectFile = Projects.getBaseDirectory(project).toPath()
+                .resolve("project." + ProjectIO.DEFAULT_PROJECT_EXTENSION);
+        String projectName = project.getName();
+        List<ExclusionReport> allReports = new ArrayList<>();
+
+        for (ProjectImageEntry<BufferedImage> entry : project.getImageList()) {
+            ImageData<BufferedImage> imageData;
+            try {
+                imageData = entry.readImageData();
+            } catch (IOException e) {
+                logger.error("Failed to read image data {}: {}", entry.getImageName(), e.getMessage());
+                continue;
+            }
+            try {
+                if (!AtlasManager.isImported(imageData.getHierarchy())) {
+                    logger.warn("No imported atlas found for {}", entry.getImageName());
+                    continue;
+                }
+                AtlasManager atlas = new AtlasManager(imageData.getHierarchy());
+                List<ExclusionReport> reports = atlas.autoExcludeEmptyRegions(imageData, channelNames,
+                        useMaxAcrossChannels, thresholdMultiplier);
+                for (ExclusionReport r : reports) {
+                    allReports.add(new ExclusionReport(projectFile, projectName, entry.getImageName(),
+                            r.excludedAnnotationId(), r.regionName(), r.percentile()));
+                }
+                entry.saveImageData(imageData);
+            } catch (Exception e) {
+                logger.error("Failed to auto-exclude regions for {}: {}", entry.getImageName(), e.getMessage());
+            } finally {
+                closeServer(imageData);
+            }
+        }
+
+        try {
+            project.syncChanges();
+        } catch (Exception e) {
+            logger.warn("Failed to sync project {}: {}", project.getName(), e.getMessage());
+        }
+        System.gc();
+        return allReports;
+    }
+
+    /**
+     * Runs auto-exclusion for a list of QuPath projects.
+     *
+     * @param qupath               the QuPath GUI instance
+     * @param projectFiles         list of QuPath project files (e.g.
+     *                             {@code project.qpproj})
+     * @param channelNames         the list of channel names to evaluate
+     * @param useMaxAcrossChannels if true, use the max intensity across channels
+     * @param thresholdMultiplier  multiplier applied to the adaptive threshold
+     * @return a flattened list of excluded regions for all entries across all
+     *         projects
+     * @throws IllegalArgumentException if {@code projectFiles} is null or empty
+     */
+    public static List<ExclusionReport> runBatch(
+            QuPathGUI qupath,
+            List<Path> projectFiles,
+            List<String> channelNames,
+            boolean useMaxAcrossChannels,
+            double thresholdMultiplier) {
+        if (projectFiles == null || projectFiles.isEmpty()) {
+            throw new IllegalArgumentException("No project files provided.");
+        }
+
+        List<ExclusionReport> allReports = new ArrayList<>();
+
+        for (Path projectFile : projectFiles) {
+            Project<BufferedImage> project;
+            try {
+                project = ProjectIO.loadProject(projectFile.toFile(), BufferedImage.class);
+            } catch (IOException e) {
+                logger.error("Failed to load project {}: {}", projectFile, e.getMessage());
+                continue;
+            }
+            FXUtils.runOnApplicationThread(() -> qupath.setProject(project));
+            String projectName = project.getName();
+
+            for (ProjectImageEntry<BufferedImage> entry : project.getImageList()) {
+                ImageData<BufferedImage> imageData;
+                try {
+                    imageData = entry.readImageData();
+                } catch (IOException e) {
+                    logger.error("Failed to read image data {}: {}", entry.getImageName(), e.getMessage());
+                    continue;
+                }
+                try {
+                    if (!AtlasManager.isImported(imageData.getHierarchy())) {
+                        logger.warn("No imported atlas found for {}", entry.getImageName());
+                        continue;
+                    }
+                    AtlasManager atlas = new AtlasManager(imageData.getHierarchy());
+                    List<ExclusionReport> reports = atlas.autoExcludeEmptyRegions(imageData, channelNames,
+                            useMaxAcrossChannels, thresholdMultiplier);
+                    for (ExclusionReport r : reports) {
+                        allReports.add(new ExclusionReport(projectFile, projectName, entry.getImageName(),
+                                r.excludedAnnotationId(), r.regionName(), r.percentile()));
+                    }
+                    entry.saveImageData(imageData);
+                } catch (Exception e) {
+                    logger.error("Failed to auto-exclude regions for {}: {}", entry.getImageName(), e.getMessage());
+                } finally {
+                    closeServer(imageData);
+                }
+            }
+
+            try {
+                project.syncChanges();
+            } catch (Exception e) {
+                logger.warn("Failed to sync project {}: {}", projectFile, e.getMessage());
+            }
+            System.gc();
+            FXUtils.runOnApplicationThread(() -> Commands.closeProject(qupath));
+        }
+        return allReports;
+    }
+
+    /**
+     * Retrieves the excluded regions for every entry of the current QuPath project.
+     *
+     * @param qupath the QuPath GUI instance
+     * @return a flattened list of excluded regions for all entries
+     * @throws IllegalStateException if no project is open
+     */
+    public static List<ExclusionReport> getExcludedRegionsCurrentProject(QuPathGUI qupath) {
+        Project<BufferedImage> project = qupath.getProject();
+        if (project == null) {
+            throw new IllegalStateException("No project open.");
+        }
+        Path projectFile = Projects.getBaseDirectory(project).toPath()
+                .resolve("project." + ProjectIO.DEFAULT_PROJECT_EXTENSION);
+        String projectName = project.getName();
+        List<ExclusionReport> all = new ArrayList<>();
+
+        for (ProjectImageEntry<BufferedImage> entry : project.getImageList()) {
+            ImageData<BufferedImage> imageData;
+            try {
+                imageData = entry.readImageData();
+            } catch (IOException e) {
+                logger.error("Failed to read image data {}: {}", entry.getImageName(), e.getMessage());
+                continue;
+            }
+            try {
+                List<ExclusionReport> reports;
+                if (AtlasManager.isImported(imageData.getHierarchy())) {
+                    AtlasManager atlas = new AtlasManager(imageData.getHierarchy());
+                    reports = atlas.getExcludedRegions(imageData);
+                } else {
+                    reports = imageData.getHierarchy().getAnnotationObjects().stream()
+                            .filter(o -> o.getPathClass() == AtlasManager.EXCLUDE_CLASSIFICATION)
+                            .map(o -> new ExclusionReport(null, null, entry.getImageName(), o.getID(), o.getName(),
+                                    Double.NaN))
+                            .toList();
+                }
+                for (ExclusionReport r : reports) {
+                    all.add(new ExclusionReport(projectFile, projectName, entry.getImageName(),
+                            r.excludedAnnotationId(), r.regionName(), r.percentile()));
+                }
+            } catch (Exception e) {
+                logger.error("Failed to gather exclusions for {}: {}", entry.getImageName(), e.getMessage());
+            } finally {
+                closeServer(imageData);
+            }
+        }
+
+        return all;
+    }
+
+    private static void closeServer(ImageData<BufferedImage> imageData) {
+        try {
+            imageData.getServer().close();
+        } catch (Exception e) {
+            logger.warn("Failed to close image server: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/qupath/ext/braian/runners/BraiAnAnalysisRunner.java
+++ b/src/main/java/qupath/ext/braian/runners/BraiAnAnalysisRunner.java
@@ -1,0 +1,392 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.runners;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.ext.braian.AtlasManager;
+import qupath.ext.braian.AbstractDetections;
+import qupath.ext.braian.ChannelDetections;
+import qupath.ext.braian.ImageChannelTools;
+import qupath.ext.braian.NoCellContainersFoundException;
+import qupath.ext.braian.OverlappingDetections;
+import qupath.ext.braian.config.ChannelClassifierConfig;
+import qupath.ext.braian.config.ChannelDetectionsConfig;
+import qupath.ext.braian.config.ProjectsConfig;
+import qupath.ext.braian.PartialClassifier;
+import qupath.ext.braian.utils.ProjectDiscoveryService;
+import qupath.fx.utils.FXUtils;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.commands.Commands;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathAnnotationObject;
+import qupath.lib.projects.Project;
+import qupath.lib.projects.ProjectIO;
+import qupath.lib.projects.ProjectImageEntry;
+import qupath.lib.projects.Projects;
+
+import java.awt.image.BufferedImage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Main execution runner for the BraiAn analysis pipeline.
+ * <p>
+ * This runner loads {@link ProjectsConfig} and orchestrates:
+ * <ul>
+ * <li>optional channel renaming</li>
+ * <li>cell detections per channel</li>
+ * <li>per-channel object classification</li>
+ * <li>optional overlaps computation</li>
+ * <li>export of regional results via {@link AtlasManager}</li>
+ * <li>optional pixel classification via {@link PixelClassifierRunner}</li>
+ * </ul>
+ */
+public final class BraiAnAnalysisRunner {
+    private static final Logger logger = LoggerFactory.getLogger(BraiAnAnalysisRunner.class);
+    private static final String CONFIG_FILENAME = "BraiAn.yml";
+
+    private BraiAnAnalysisRunner() {
+    }
+
+    /**
+     * Runs the pipeline for the currently open image, without exporting results.
+     *
+     * @param qupath the QuPath GUI instance
+     * @throws IllegalStateException if no project or no image is open
+     */
+    public static void runPreview(QuPathGUI qupath) {
+        Project<BufferedImage> project = qupath.getProject();
+        if (project == null) {
+            throw new IllegalStateException("No project open.");
+        }
+        ProjectsConfig config = loadConfigForProject(project);
+        ImageData<BufferedImage> imageData = qupath.getViewer() != null ? qupath.getViewer().getImageData() : null;
+        if (imageData == null) {
+            throw new IllegalStateException("No image open.");
+        }
+        processImage(qupath, imageData, project, null, config, false);
+    }
+
+    /**
+     * Runs the pipeline for all images in the current project and exports results.
+     *
+     * @param qupath the QuPath GUI instance
+     * @throws IllegalStateException if no project is open
+     */
+    public static void runProject(QuPathGUI qupath) {
+        Project<BufferedImage> project = qupath.getProject();
+        if (project == null) {
+            throw new IllegalStateException("No project open.");
+        }
+        ProjectsConfig config = loadConfigForProject(project);
+        runProjectImages(qupath, project, config, true);
+    }
+
+    /**
+     * Discovers QuPath projects under {@code rootPath} and runs the pipeline for
+     * each.
+     *
+     * @param qupath   the QuPath GUI instance
+     * @param rootPath root directory containing QuPath projects and a shared
+     *                 {@code BraiAn.yml}
+     * @throws IllegalArgumentException if {@code rootPath} is invalid
+     */
+    public static void runBatch(QuPathGUI qupath, Path rootPath) {
+        if (rootPath == null || !Files.isDirectory(rootPath)) {
+            throw new IllegalArgumentException("Invalid projects directory: " + rootPath);
+        }
+        List<Path> projectFiles = ProjectDiscoveryService.discoverProjectFiles(rootPath);
+        runBatch(qupath, rootPath, projectFiles);
+    }
+
+    /**
+     * Runs the pipeline for a list of QuPath projects.
+     *
+     * @param qupath       the QuPath GUI instance
+     * @param rootPath     root directory containing a shared {@code BraiAn.yml}
+     * @param projectFiles list of QuPath project files (e.g.
+     *                     {@code project.qpproj})
+     * @throws IllegalArgumentException if {@code rootPath} is invalid
+     * @throws IllegalStateException    if {@code projectFiles} is null or empty
+     */
+    public static void runBatch(QuPathGUI qupath, Path rootPath, List<Path> projectFiles) {
+        if (rootPath == null || !Files.isDirectory(rootPath)) {
+            throw new IllegalArgumentException("Invalid projects directory: " + rootPath);
+        }
+        ProjectsConfig config = loadConfig(rootPath.resolve(CONFIG_FILENAME));
+        if (projectFiles == null || projectFiles.isEmpty()) {
+            throw new IllegalStateException("No QuPath projects found in " + rootPath);
+        }
+
+        for (Path projectFile : projectFiles) {
+            Project<BufferedImage> project;
+            try {
+                project = ProjectIO.loadProject(projectFile.toFile(), BufferedImage.class);
+            } catch (IOException e) {
+                logger.error("Failed to load project {}: {}", projectFile, e.getMessage());
+                continue;
+            }
+            FXUtils.runOnApplicationThread(() -> qupath.setProject(project));
+            runProjectImages(qupath, project, config, true);
+            FXUtils.runOnApplicationThread(() -> Commands.closeProject(qupath));
+        }
+    }
+
+    private static void runProjectImages(QuPathGUI qupath,
+            Project<BufferedImage> project,
+            ProjectsConfig config,
+            boolean export) {
+        for (ProjectImageEntry<BufferedImage> entry : project.getImageList()) {
+            ImageData<BufferedImage> imageData;
+            try {
+                imageData = entry.readImageData();
+            } catch (IOException e) {
+                logger.error("Failed to read image data {}: {}", entry.getImageName(), e.getMessage());
+                continue;
+            }
+            try {
+                processImage(qupath, imageData, project, entry, config, export);
+                entry.saveImageData(imageData);
+            } catch (Exception e) {
+                logger.error("Failed processing {}", entry.getImageName(), e);
+            } finally {
+                closeServer(imageData);
+            }
+        }
+        try {
+            project.syncChanges();
+        } catch (Exception e) {
+            logger.warn("Failed to sync project {}: {}", project.getName(), e.getMessage());
+        }
+        System.gc();
+    }
+
+    private static void processImage(QuPathGUI qupath,
+            ImageData<BufferedImage> imageData,
+            Project<BufferedImage> project,
+            ProjectImageEntry<BufferedImage> entry,
+            ProjectsConfig config,
+            boolean export) {
+        var hierarchy = imageData.getHierarchy();
+        List<ChannelDetectionsConfig> channelConfigs = Optional.ofNullable(config.getChannelDetections())
+                .orElse(List.of());
+        boolean enableCellDetection = channelConfigs.stream()
+                .anyMatch(ChannelDetectionsConfig::isEnableCellDetection);
+        boolean enablePixelClassification = channelConfigs.stream()
+                .anyMatch(ChannelDetectionsConfig::isEnablePixelClassification);
+
+        List<ChannelDetections> allDetections = new ArrayList<>();
+        List<OverlappingDetections> overlaps = new ArrayList<>();
+
+        if (enableCellDetection) {
+            applyChannelRenaming(imageData, config);
+            Collection<PathAnnotationObject> annotations = config.getAnnotationsForDetections(hierarchy);
+            for (ChannelDetectionsConfig detectionsConfig : channelConfigs) {
+                if (!detectionsConfig.isEnableCellDetection()) {
+                    continue;
+                }
+                String name = detectionsConfig.getName();
+                if (name == null || name.isBlank()) {
+                    continue;
+                }
+                try {
+                    ImageChannelTools channel = new ImageChannelTools(name, imageData);
+                    ChannelDetections detections = new ChannelDetections(channel, annotations,
+                            detectionsConfig.getParameters(), hierarchy, imageData, project, qupath);
+                    allDetections.add(detections);
+                } catch (IllegalArgumentException e) {
+                    logger.warn("Skipping {}: {}", name, e.getMessage());
+                } catch (NoCellContainersFoundException e) {
+                    logger.warn("No detections found for {}", name);
+                }
+            }
+
+            if (allDetections.isEmpty()) {
+                String label = entry != null ? entry.getImageName() : imageData.getServerMetadata().getName();
+                logger.info("{}: no detections computed", label);
+            } else {
+                for (ChannelDetections detections : allDetections) {
+                    ChannelDetectionsConfig detectionsConfig = channelConfigs.stream()
+                            .filter(conf -> detections.getId().equals(conf.getName()))
+                            .findFirst()
+                            .orElse(null);
+                    if (detectionsConfig == null || detectionsConfig.getClassifiers() == null) {
+                        continue;
+                    }
+                    List<PartialClassifier<BufferedImage>> partialClassifiers = new ArrayList<>();
+                    for (ChannelClassifierConfig classifierConfig : detectionsConfig.getClassifiers()) {
+                        try {
+                            partialClassifiers.add(classifierConfig.toPartialClassifier(hierarchy, project));
+                        } catch (IOException e) {
+                            logger.warn("Failed to load classifier {}: {}", classifierConfig.getName(), e.getMessage());
+                        }
+                    }
+                    detections.applyClassifiers(partialClassifiers, imageData);
+                }
+
+                config.getControlChannel().ifPresent(controlName -> {
+                    ChannelDetections control = allDetections.stream()
+                            .filter(det -> det.getId().equals(controlName))
+                            .findFirst()
+                            .orElse(null);
+                    if (control == null) {
+                        return;
+                    }
+                    List<ChannelDetections> others = allDetections.stream()
+                            .filter(det -> !det.getId().equals(controlName))
+                            .toList();
+                    if (others.isEmpty()) {
+                        return;
+                    }
+                    try {
+                        List<AbstractDetections> otherDetections = new ArrayList<>(others);
+                        overlaps.add(
+                                new OverlappingDetections(control, otherDetections, true, hierarchy, project, qupath));
+                    } catch (NoCellContainersFoundException e) {
+                        logger.warn("Unable to compute overlaps: {}", e.getMessage());
+                    }
+                });
+
+                if (export && project != null && entry != null) {
+                    String atlasName = config.getAtlasName();
+                    if (atlasName == null) {
+                        atlasName = "allen_mouse_10um_java";
+                    }
+
+                    if (!AtlasManager.isImported(atlasName, hierarchy)) {
+                        logger.warn("No atlas '{}' imported for {}", atlasName, entry.getImageName());
+                    } else {
+                        try {
+                            AtlasManager atlas = new AtlasManager(atlasName, hierarchy);
+                            atlas.fixExclusions();
+                            String imageName = sanitizeFileName(entry.getImageName());
+                            Path projectDir = Projects.getBaseDirectory(project).toPath();
+                            Path resultsPath = projectDir.resolve("results").resolve(imageName + "_regions.tsv");
+                            Path exclusionsPath = projectDir.resolve("regions_to_exclude")
+                                    .resolve(imageName + "_regions_to_exclude.txt");
+                            atlas.saveResults(concat(allDetections, overlaps), resultsPath.toFile(), imageData, entry);
+                            atlas.saveExcludedRegions(exclusionsPath.toFile());
+                        } catch (RuntimeException e) {
+                            logger.error("Failed to export results for {}: {}", entry.getImageName(), e.getMessage());
+                        }
+                    }
+                }
+            }
+        }
+
+        if (enablePixelClassification) {
+            PixelClassifierRunner.runPixelClassifiers(qupath, imageData, project, entry, config,
+                    new ArrayList<>(allDetections), export);
+        }
+    }
+
+    private static ProjectsConfig loadConfigForProject(Project<BufferedImage> project) {
+        try {
+            return ProjectsConfig.read(project, CONFIG_FILENAME);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to load BraiAn.yml: " + e.getMessage(), e);
+        }
+    }
+
+    private static ProjectsConfig loadConfig(Path configPath) {
+        try {
+            return ProjectsConfig.read(configPath);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to load BraiAn.yml: " + e.getMessage(), e);
+        }
+    }
+
+    private static void closeServer(ImageData<BufferedImage> imageData) {
+        try {
+            imageData.getServer().close();
+        } catch (Exception e) {
+            logger.warn("Failed to close image server: {}", e.getMessage());
+        }
+    }
+
+    private static List<AbstractDetections> concat(List<ChannelDetections> detections,
+            List<OverlappingDetections> overlaps) {
+        List<AbstractDetections> merged = new ArrayList<>(detections);
+        for (OverlappingDetections overlap : overlaps) {
+            merged.add(overlap);
+        }
+        return merged;
+    }
+
+    private static String sanitizeFileName(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "image";
+        }
+        String sanitized = raw.replaceAll("[<>:\"/\\\\|?*]", "");
+        if (sanitized.isBlank()) {
+            return "image";
+        }
+        return sanitized;
+    }
+
+    private static void applyChannelRenaming(ImageData<BufferedImage> imageData, ProjectsConfig config) {
+        var channelConfigs = config.getChannelDetections();
+        if (channelConfigs == null || channelConfigs.isEmpty()) {
+            return;
+        }
+
+        var metadata = imageData.getServerMetadata();
+        var channels = metadata.getChannels();
+        List<String> currentNames = new ArrayList<>();
+        for (var ch : channels) {
+            currentNames.add(ch.getName());
+        }
+
+        boolean changed = false;
+        for (ChannelDetectionsConfig chConfig : channelConfigs) {
+            int inputId = chConfig.getInputChannelID(); // 1-based
+            String targetName = chConfig.getName();
+
+            if (inputId > 0 && inputId <= currentNames.size() && targetName != null && !targetName.isBlank()) {
+                // Check if rename is needed
+                int index = inputId - 1;
+                if (!currentNames.get(index).equals(targetName)) {
+                    currentNames.set(index, targetName);
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed) {
+            try {
+                var server = imageData.getServer();
+                var oldMetadata = server.getMetadata();
+                var oldChannels = oldMetadata.getChannels();
+
+                // Build new channel list with updated names
+                List<qupath.lib.images.servers.ImageChannel> newChannels = new ArrayList<>();
+                for (int i = 0; i < oldChannels.size(); i++) {
+                    var oldChannel = oldChannels.get(i);
+                    String newName = currentNames.get(i);
+                    newChannels.add(qupath.lib.images.servers.ImageChannel.getInstance(newName, oldChannel.getColor()));
+                }
+
+                // Create new metadata with updated channels
+                var newMetadata = new qupath.lib.images.servers.ImageServerMetadata.Builder(oldMetadata)
+                        .channels(newChannels)
+                        .build();
+                imageData.updateServerMetadata(newMetadata);
+                logger.info("Updated channel names to: {}", currentNames);
+            } catch (Exception e) {
+                logger.error("Failed to update channel names: {}", e.getMessage());
+            }
+        }
+    }
+
+    // Project file discovery is delegated to ProjectDiscoveryService.
+}

--- a/src/main/java/qupath/ext/braian/runners/ClassifierSampleRunner.java
+++ b/src/main/java/qupath/ext/braian/runners/ClassifierSampleRunner.java
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.runners;
+
+import javafx.application.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.ext.braian.utils.ProjectDiscoveryService;
+import qupath.fx.dialogs.Dialogs;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.projects.Project;
+import qupath.lib.projects.ProjectIO;
+import qupath.lib.projects.ProjectImageEntry;
+import qupath.lib.projects.Projects;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Runner to sample images from multiple projects and create a new project for
+ * classifier training.
+ */
+public class ClassifierSampleRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClassifierSampleRunner.class);
+
+    /**
+     * Runs the sampling process.
+     *
+     * @param qupath            The QuPath GUI instance.
+     * @param experimentRoot    The root directory containing experiment projects.
+     * @param samplesPerProject Number of images to sample from each project.
+     * @param newProjectName    Name of the new project to create.
+     * @throws IOException If creating the project or copying files fails.
+     */
+    public static void run(QuPathGUI qupath, Path experimentRoot, int samplesPerProject, String newProjectName)
+            throws IOException {
+        logger.info("Starting classifier sample run...");
+        logger.info("Root: {}, Samples: {}, Name: {}", experimentRoot, samplesPerProject, newProjectName);
+
+        List<Path> projectFiles = ProjectDiscoveryService.discoverProjectFiles(experimentRoot);
+        if (projectFiles.isEmpty()) {
+            throw new IOException("No projects found in " + experimentRoot);
+        }
+
+        Path newProjectDir = experimentRoot.resolve(newProjectName);
+        if (Files.exists(newProjectDir)) {
+            throw new IOException("Project directory already exists: " + newProjectDir);
+        }
+        Files.createDirectories(newProjectDir);
+
+        Project<BufferedImage> newProject = Projects.createProject(newProjectDir.toFile(), BufferedImage.class);
+        newProject.syncChanges();
+
+        for (Path projectFile : projectFiles) {
+            // Avoid recursively processing the new project if it gets discovered or is in
+            // the list
+            if (projectFile.getParent() != null && projectFile.getParent().equals(newProjectDir))
+                continue;
+
+            try {
+                // Must ensure project is not read-only for us to read from it
+                Project<BufferedImage> sourceProject = ProjectIO.loadProject(projectFile.toFile(), BufferedImage.class);
+                List<ProjectImageEntry<BufferedImage>> images = new ArrayList<>(sourceProject.getImageList());
+                Collections.shuffle(images);
+
+                int count = 0;
+                for (ProjectImageEntry<BufferedImage> entry : images) {
+                    if (count >= samplesPerProject)
+                        break;
+
+                    // Use copyData = true to let QuPath handle file copying (images, thumbnails,
+                    // data.qpdata)
+                    newProject.addDuplicate(entry, true);
+                    count++;
+                }
+
+            } catch (Exception e) {
+                logger.error("Error processing project " + projectFile, e);
+            }
+        }
+
+        newProject.syncChanges();
+
+        final Project<BufferedImage> finalProject = newProject;
+        Platform.runLater(() -> {
+            qupath.setProject(finalProject);
+            Dialogs.showInfoNotification("Classifier Training", "Created and opened " + newProjectName);
+        });
+    }
+}

--- a/src/main/java/qupath/ext/braian/runners/PixelClassifierRunner.java
+++ b/src/main/java/qupath/ext/braian/runners/PixelClassifierRunner.java
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: 2024 Carlo Castoldi <carlo.castoldi@outlook.com>
+// SPDX-FileCopyrightText: 2025 Nash Baughman <nfbaughman@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package qupath.ext.braian.runners;
+
+import ij.measure.ResultsTable;
+import javafx.application.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.ext.braian.AbstractDetections;
+import qupath.ext.braian.AtlasManager;
+import qupath.ext.braian.config.ChannelDetectionsConfig;
+import qupath.ext.braian.config.PixelClassifierConfig;
+import qupath.ext.braian.config.ProjectsConfig;
+import qupath.ext.braian.utils.BraiAn;
+import qupath.lib.classifiers.pixel.PixelClassifier;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.measure.ObservableMeasurementTableData;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObject;
+import qupath.lib.projects.Project;
+import qupath.lib.projects.ProjectImageEntry;
+import qupath.lib.projects.Projects;
+import qupath.opencv.ml.pixel.PixelClassifierTools;
+import qupath.opencv.ml.pixel.PixelClassifiers;
+
+import java.awt.image.BufferedImage;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+
+/**
+ * Runner for pixel classifier execution and results export.
+ * <p>
+ * This class applies configured pixel classifiers to atlas regions and
+ * optionally exports measurements
+ * to TSV files.
+ */
+public final class PixelClassifierRunner {
+    private static final Logger logger = LoggerFactory.getLogger(PixelClassifierRunner.class);
+
+    private PixelClassifierRunner() {
+    }
+
+    /**
+     * Runs configured pixel classifiers for an image and optionally exports
+     * results.
+     *
+     * @param qupath     the QuPath GUI instance
+     * @param imageData  the image to process
+     * @param project    the current project; required for export
+     * @param entry      the project entry corresponding to {@code imageData};
+     *                   required for export
+     * @param config     the BraiAn configuration
+     * @param detections optional list of detections used to determine which atlas
+     *                   regions to include
+     * @param export     if true, exports results to the project {@code results/}
+     *                   directory
+     * @throws IllegalArgumentException if {@code imageData} is null
+     */
+    public static void runPixelClassifiers(QuPathGUI qupath,
+            ImageData<BufferedImage> imageData,
+            Project<BufferedImage> project,
+            ProjectImageEntry<BufferedImage> entry,
+            ProjectsConfig config,
+            List<? extends AbstractDetections> detections,
+            boolean export) {
+        if (imageData == null) {
+            throw new IllegalArgumentException("ImageData is required for pixel classification.");
+        }
+
+        List<ChannelDetectionsConfig> channelConfigs = Optional.ofNullable(config.getChannelDetections())
+                .orElse(List.of());
+        List<PixelClassifierConfig> classifierConfigs = new ArrayList<>();
+        for (ChannelDetectionsConfig channelConfig : channelConfigs) {
+            if (!channelConfig.isEnablePixelClassification()) {
+                continue;
+            }
+            List<PixelClassifierConfig> pixelClassifiers = Optional.ofNullable(channelConfig.getPixelClassifiers())
+                    .orElse(List.of());
+            classifierConfigs.addAll(pixelClassifiers);
+        }
+        if (classifierConfigs.isEmpty()) {
+            logger.info("No pixel classifiers configured.");
+            return;
+        }
+
+        String atlasName = config.getAtlasName();
+        if (atlasName == null || atlasName.isBlank()) {
+            atlasName = "allen_mouse_10um_java";
+        }
+
+        var hierarchy = imageData.getHierarchy();
+        String label = entry != null ? entry.getImageName() : imageData.getServerMetadata().getName();
+        if (!AtlasManager.isImported(atlasName, hierarchy)) {
+            logger.warn("No atlas '{}' imported for {}", atlasName, label);
+            return;
+        }
+
+        AtlasManager atlas = new AtlasManager(atlasName, hierarchy);
+        List<PathObject> baseRegions = detections != null && !detections.isEmpty()
+                ? atlas.flatten(new ArrayList<>(detections))
+                : atlas.flatten();
+        if (baseRegions.isEmpty()) {
+            logger.warn("No atlas regions available for pixel classification.");
+            return;
+        }
+
+        List<String> measurementIds = new ArrayList<>();
+        for (PixelClassifierConfig classifierConfig : classifierConfigs) {
+            String classifierName = trimToNull(classifierConfig.getClassifierName());
+            String measurementId = trimToNull(classifierConfig.getMeasurementId());
+            if (classifierName == null) {
+                logger.warn("Skipping pixel classifier with empty name.");
+                continue;
+            }
+            if (measurementId == null) {
+                logger.warn("Skipping pixel classifier '{}' without measurement ID.", classifierName);
+                continue;
+            }
+
+            Path classifierPath;
+            try {
+                classifierPath = resolveClassifierPath(project, classifierName);
+            } catch (FileNotFoundException e) {
+                logger.warn("Failed to resolve pixel classifier {}: {}", classifierName, e.getMessage());
+                continue;
+            }
+
+            PixelClassifier classifier;
+            try {
+                classifier = PixelClassifiers.readClassifier(classifierPath);
+            } catch (IOException e) {
+                logger.warn("Failed to load pixel classifier {}: {}", classifierName, e.getMessage());
+                continue;
+            }
+
+            List<PathObject> targetRegions = filterRegions(baseRegions, classifierConfig.getRegionFilter());
+            if (targetRegions.isEmpty()) {
+                logger.warn("No atlas regions matched filter for pixel classifier '{}'", classifierName);
+                continue;
+            }
+
+            boolean applied = applyPixelClassifierOnFxThread(imageData, classifier, measurementId, targetRegions);
+            if (applied && !measurementIds.contains(measurementId)) {
+                measurementIds.add(measurementId);
+            }
+        }
+
+        if (!export || project == null || entry == null || measurementIds.isEmpty()) {
+            return;
+        }
+
+        Path projectDir = Projects.getBaseDirectory(project).toPath();
+        exportResults(projectDir, entry, imageData, baseRegions, measurementIds);
+    }
+
+    private static Path resolveClassifierPath(Project<?> project, String classifierName) throws FileNotFoundException {
+        String fileName = classifierName.toLowerCase().endsWith(".json")
+                ? classifierName
+                : classifierName + ".json";
+        return BraiAn.resolvePath(project, fileName);
+    }
+
+    private static void exportResults(Path projectDir,
+            ProjectImageEntry<BufferedImage> entry,
+            ImageData<BufferedImage> imageData,
+            List<PathObject> regions,
+            List<String> measurementIds) {
+        ResultsTable results = new ResultsTable();
+        ObservableMeasurementTableData ob = new ObservableMeasurementTableData();
+        ob.setImageData(imageData, regions);
+
+        String rawImageName = entry.getImageName();
+        String imageName = sanitizeFileName(rawImageName);
+        String areaColumn = "Area " + AtlasManager.um + "^2";
+
+        for (PathObject region : regions) {
+            results.incrementCounter();
+            results.addValue("Image Name", rawImageName);
+
+            Map<String, String> metadata = entry.getMetadata();
+            if (metadata != null && !metadata.isEmpty()) {
+                for (String key : metadata.keySet()) {
+                    results.addValue("Metadata_" + key, metadata.get(key));
+                }
+            }
+
+            String regionName = region.getName();
+            results.addValue("Region", regionName == null ? "" : regionName);
+            if (region.getPathClass() != null) {
+                results.addValue("Classification", region.getPathClass().toString());
+            }
+
+            if (ob.isNumericMeasurement(areaColumn)) {
+                double areaValue = ob.getNumericValue(region, areaColumn);
+                results.addValue(areaColumn.replace(AtlasManager.um, "um"), areaValue);
+            }
+
+            for (String measurementId : measurementIds) {
+                double value = ob.getNumericValue(region, measurementId);
+                results.addValue(measurementId, value);
+            }
+        }
+
+        Path resultsPath = projectDir.resolve("results").resolve(imageName + "_pixel_classifiers.tsv");
+        try {
+            Files.createDirectories(resultsPath.getParent());
+        } catch (IOException e) {
+            logger.error("Failed to create directory {}: {}", resultsPath.getParent(), e.getMessage());
+            return;
+        }
+
+        boolean saved = results.save(resultsPath.toString());
+        if (saved) {
+            logger.info("Pixel classifier results saved under '{}'", resultsPath);
+        } else {
+            logger.warn("Failed to save pixel classifier results under '{}'", resultsPath);
+        }
+    }
+
+    private static List<PathObject> filterRegions(List<PathObject> regions, List<String> filter) {
+        if (filter == null || filter.isEmpty()) {
+            return regions;
+        }
+        List<String> names = filter.stream()
+                .filter(name -> name != null && !name.isBlank())
+                .map(String::trim)
+                .toList();
+        if (names.isEmpty()) {
+            return regions;
+        }
+        List<PathObject> filtered = new ArrayList<>();
+        for (PathObject region : regions) {
+            String regionName = region.getName();
+            if (regionName != null && names.contains(regionName)) {
+                filtered.add(region);
+            }
+        }
+        return filtered;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static String sanitizeFileName(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "image";
+        }
+        String sanitized = raw.replaceAll("[<>:\"/\\\\|?*]", "");
+        if (sanitized.isBlank()) {
+            return "image";
+        }
+        return sanitized;
+    }
+
+    private static boolean applyPixelClassifierOnFxThread(ImageData<BufferedImage> imageData,
+            PixelClassifier classifier,
+            String measurementId,
+            List<PathObject> targetRegions) {
+        if (Platform.isFxApplicationThread()) {
+            return applyPixelClassifier(imageData, classifier, measurementId, targetRegions);
+        }
+        FutureTask<Boolean> task = new FutureTask<>(
+                () -> applyPixelClassifier(imageData, classifier, measurementId, targetRegions));
+        Platform.runLater(task);
+        try {
+            return task.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warn("Pixel classifier execution interrupted for {}", measurementId, e);
+        } catch (ExecutionException e) {
+            logger.warn("Pixel classifier execution failed for {}", measurementId, e.getCause());
+        }
+        return false;
+    }
+
+    private static boolean applyPixelClassifier(ImageData<BufferedImage> imageData,
+            PixelClassifier classifier,
+            String measurementId,
+            List<PathObject> targetRegions) {
+        var hierarchy = imageData.getHierarchy();
+        hierarchy.getSelectionModel().clearSelection();
+        hierarchy.getSelectionModel().setSelectedObjects(targetRegions, null);
+        try {
+            return PixelClassifierTools.addMeasurementsToSelectedObjects(imageData, classifier, measurementId);
+        } finally {
+            hierarchy.getSelectionModel().clearSelection();
+        }
+    }
+}


### PR DESCRIPTION
Adds runner classes that orchestrate BraiAnDetect pipeline steps across images and projects.

### Motivation

The GUI and future CLI tooling need a Java-level orchestration layer that can run pipeline steps (ABBA import, auto-exclusion, pixel classification, cell detection) in batch across multiple images and projects. These runners handle image lifecycle (open, process, save, close) and error recovery.

### New classes

| Class | Lines | Purpose |
|-------|-------|---------|
| `AbbaReflectionBridge` | 101 | Reflective access to ABBA extension APIs |
| `ABBAImporterRunner` | 214 | Batch ABBA atlas import |
| `BraiAnAnalysisRunner` | 392 | End-to-end pipeline orchestrator |
| `PixelClassifierRunner` | 305 | Batch pixel classifier execution |
| `ClassifierSampleRunner` | 99 | Training set image sampler |
| `AutoExcludeEmptyRegionsRunner` | 289 | Batch auto-exclusion across projects |

### Dependencies

> **Important**: This PR depends on APIs introduced in:
> - PR 3 (`atlasName` config field, used by `BraiAnAnalysisRunner`)
> - PR 4 (`ExclusionReport`, `autoExcludeEmptyRegions`)
> - PR 6 (explicit context passing)
>
> It will compile cleanly once those PRs are merged.

### Build

`./gradlew compileJava` ⚠️ requires PR 3 + PR 4 + PR 6

_Part of the PR #7 split — see #7 for full context._